### PR TITLE
Switch to click echo for more colorful logging

### DIFF
--- a/larq_flock/cli.py
+++ b/larq_flock/cli.py
@@ -1,10 +1,6 @@
 import click
 import os
 from datetime import datetime
-import logging
-
-log = logging.getLogger(name=__name__)
-log.setLevel(logging.INFO)
 
 
 @click.group()
@@ -101,7 +97,7 @@ def prepare(datasets, data_dir):
 
     for dataset in datasets:
         tfds.builder(dataset, data_dir=data_dir).download_and_prepare()
-        log.info("Finished preparing dataset: %s", dataset)
+        click.secho(f"Finished preparing dataset: {dataset}", fg="green")
 
 
 @cli.command(context_settings=dict(allow_extra_args=True, ignore_unknown_options=True))
@@ -118,7 +114,7 @@ def prepare(datasets, data_dir):
 def tensorboard(model, dataset, output_prefix, output_dir):
     if output_dir is None:
         output_dir = os.path.join(output_prefix, dataset, model)
-    log.info("Starting TensorBoard at: %s", output_dir)
+    click.secho(f"Starting TensorBoard at: {output_dir}", fg="blue")
     os.system(f"tensorboard --logdir={output_dir}")
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/plumerai/larq-flock",
     packages=find_packages(),
     license="Apache 2.0",
-    install_requires=["click>=7.0", "tensorflow-datasets>=1.0.1"],
+    install_requires=["click>=7.0", "tensorflow-datasets>=1.0.1", "colorama>=0.4.1"],
     extras_require={
         "tensorflow": ["tensorflow>=1.13.1"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.13.1"],


### PR DESCRIPTION
Unfortunately tensorflow doesn't play well with the default logging module since it modifies the global handlers which make logs very hard to read in the console. This switches all the CLI output to colorful click echo using colorama.