### PR TITLE
Breaking Change: Remove dataset handling from zookeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,8 @@ def train(build_model, dataset, hparams, output_dir):
         metrics=["categorical_accuracy", "top_k_categorical_accuracy"],
     )
 
-    model.fit(
-        dataset.train_data(hparams.batch_size),
-        steps_per_epoch=dataset.train_examples // hparams.batch_size,
-        validation_data=dataset.validation_data(hparams.batch_size),
-        validation_steps=dataset.validation_examples // hparams.batch_size,
-    )
+    train_data = dataset.train_data(shuffle_buffer=1024).batch(hparams.batch_size).prefetch(1)
+    model.fit(train_data, epochs=hparams.epochs)
 ```
 
 This will register Click command called `train` which can be executed from the command line.

--- a/examples/train.py
+++ b/examples/train.py
@@ -56,11 +56,21 @@ def train(build_model, dataset, hparams, output_dir):
         metrics=["categorical_accuracy", "top_k_categorical_accuracy"],
     )
 
+    train_data = (
+        dataset.train_data(shuffle_buffer=1024)
+        .batch(hparams.batch_size)
+        .repeat()
+        .prefetch(1)
+    )
+    validation_data = (
+        dataset.validation_data().batch(hparams.batch_size).repeat().prefetch(1)
+    )
+
     model.fit(
-        dataset.train_data(hparams.batch_size),
+        train_data,
         epochs=hparams.epochs,
         steps_per_epoch=dataset.train_examples // hparams.batch_size,
-        validation_data=dataset.validation_data(hparams.batch_size),
+        validation_data=validation_data,
         validation_steps=dataset.validation_examples // hparams.batch_size,
     )
 


### PR DESCRIPTION
This removes most of the environment specific dataset handling from `zookeeper`.
The obvious downside is that this requires more code in userspace and users need to optimize the data pipeline themselves.

The upside of this approach is that it adds a lot more flexibility to `zookeeper` without us needing to support every `tf.data` feature through `kwargs`. E.g. we've seen OOM errors due to `AUTOTUNE` in `.prefetch()` in a not carefully configured Kubernetes environment. All of the functionality that was previously included in `zookeeper` can be easily added with just a few lines of code, so I think this will make `zookeeper` more useful in different computing environments.

In the future, I'd like to remove the current dataset caching functionality as well and replace it with the in memory caching provided by TensorFlow datasets in in the `tfds-nightly` release. The current `tf.data` disk caching functionality is quite brittle (https://github.com/tensorflow/tensorflow/issues/28860 https://github.com/tensorflow/tensorflow/issues/28798) so it is not really useful in this context anyway.