### PR TITLE
Upgrade to tensorflow-datasets-1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "click>=7.0",
         "click-completion>=0.5.1",
         "matplotlib>=3.0.3",
-        "tensorflow-datasets>=1.0.2",
+        "tensorflow-datasets>=1.1.0",
     ],
     extras_require={
         "tensorflow": ["tensorflow>=1.13.1"],

--- a/zookeeper/cli.py
+++ b/zookeeper/cli.py
@@ -46,6 +46,12 @@ def build_train(preload=None):
             help="A directory on the filesystem to use for caching the dataset. If `--data-cache=memory`, the dataset will be cached in memory.",
         )
         @click.option(
+            "--dataset-version",
+            "dataset_version",
+            type=str,
+            help="The version of the TensorFlow dataset. See https://github.com/tensorflow/datasets/blob/master/docs/datasets_versioning.md",
+        )
+        @click.option(
             "--output-prefix",
             default=os.path.expanduser("~/zookeeper-logs"),
             help="Directory prefix used to save model checkpoints and logs.",
@@ -70,6 +76,7 @@ def build_train(preload=None):
             hparams_str,
             data_dir,
             data_cache,
+            dataset_version,
             output_prefix,
             output_dir,
             validationset,
@@ -87,6 +94,7 @@ def build_train(preload=None):
                 use_val_split=validationset,
                 cache_dir=data_cache,
                 data_dir=data_dir,
+                version=dataset_version,
             )
             build_model = registry.get_model_function(model_name)
             hparams = registry.get_hparams(model_name, hparams_set)

--- a/zookeeper/cli.py
+++ b/zookeeper/cli.py
@@ -168,7 +168,7 @@ def plot(dataset, preprocess_fn, data_dir, output_prefix, format):
     set = registry.get_dataset(dataset, preprocess_fn, data_dir=data_dir)
     figs = data_vis.plot_all_examples(set.load_split(set.train_split), set.map_fn)
     for fig, filename in zip(figs, ("raw", "train", "eval")):
-        fig.savefig(output_dir.joinpath(filename).absolute(), format=format)
+        fig.savefig(f"{output_dir.joinpath(filename).absolute()}.{format}")
 
 
 @cli.command()

--- a/zookeeper/cli.py
+++ b/zookeeper/cli.py
@@ -166,7 +166,7 @@ def plot(dataset, preprocess_fn, data_dir, output_prefix, format):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     set = registry.get_dataset(dataset, preprocess_fn, data_dir=data_dir)
-    figs = data_vis.plot_all_examples(set.load_split(set.train_split), set.map_fn)
+    figs = data_vis.plot_all_examples(set)
     for fig, filename in zip(figs, ("raw", "train", "eval")):
         fig.savefig(f"{output_dir.joinpath(filename).absolute()}.{format}")
 

--- a/zookeeper/data.py
+++ b/zookeeper/data.py
@@ -14,13 +14,15 @@ class Dataset:
         use_val_split=False,
         cache_dir=None,
         data_dir=None,
+        version=None,
     ):
         self.dataset_name = dataset_name
         self.preprocess_fn = preprocess_fn
         self.data_dir = data_dir
         self.cache_dir = cache_dir
+        self.version = version
 
-        dataset_builder = tfds.builder(dataset_name)
+        dataset_builder = tfds.builder(self.dataset_name_str)
         self.info = dataset_builder.info
         splits = self.info.splits
         features = self.info.features
@@ -54,9 +56,15 @@ class Dataset:
                 self.validation_split = self.test_split
                 self.validation_examples = self.test_examples
 
+    @property
+    def dataset_name_str(self):
+        return (
+            f"{self.dataset_name}:{self.version}" if self.version else self.dataset_name
+        )
+
     def load_split(self, split, shuffle=True):
         return tfds.load(
-            name=self.dataset_name,
+            name=self.dataset_name_str,
             split=split,
             data_dir=self.data_dir,
             decoders={"image": tfds.decode.SkipDecoding()},
@@ -82,7 +90,7 @@ class Dataset:
         for i in range(3):
             cache_dir = os.path.join(
                 self.cache_dir,
-                self.dataset_name if i == 0 else f"{self.dataset_name}_{i}",
+                self.dataset_name_str if i == 0 else f"{self.dataset_name_str}_{i}",
             )
             if not glob.glob(f"{cache_dir}/*.lockfile"):
                 os.makedirs(cache_dir, exist_ok=True)

--- a/zookeeper/data.py
+++ b/zookeeper/data.py
@@ -6,18 +6,6 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 
-def _with_options(dataset):
-    """Applies optimization options from tfds-nightly to given dataset.
-    """
-    options = tf.data.Options()
-    options.experimental_threading.max_intra_op_parallelism = 1
-    options.experimental_threading.private_threadpool_size = 16
-    options.experimental_optimization.apply_default_optimizations = True
-    options.experimental_optimization.map_fusion = True
-    options.experimental_optimization.map_parallelization = True
-    return dataset.with_options(options)
-
-
 class Dataset:
     def __init__(
         self,
@@ -104,7 +92,7 @@ class Dataset:
 
     def train_data(self, batch_size):
         return (
-            self.maybe_cache(_with_options(self.load_split(self.train_split)), "train")
+            self.maybe_cache(self.load_split(self.train_split), "train")
             .shuffle(10 * batch_size)
             .repeat()
             .map(
@@ -125,8 +113,7 @@ class Dataset:
 
     def _get_eval_data(self, dataset, batch_size):
         return (
-            _with_options(dataset)
-            .repeat()
+            dataset.repeat()
             .map(self.map_fn, num_parallel_calls=tf.data.experimental.AUTOTUNE)
             .batch(batch_size)
             .prefetch(1)

--- a/zookeeper/data.py
+++ b/zookeeper/data.py
@@ -100,7 +100,7 @@ class Dataset:
                 num_parallel_calls=tf.data.experimental.AUTOTUNE,
             )
             .batch(batch_size)
-            .prefetch(tf.data.experimental.AUTOTUNE)
+            .prefetch(1)
         )
 
     def validation_data(self, batch_size):

--- a/zookeeper/data_vis.py
+++ b/zookeeper/data_vis.py
@@ -27,8 +27,11 @@ def plot_examples(dataset):
     return fig
 
 
-def plot_all_examples(dataset, map_fn):
-    raw = plot_examples(dataset.map(lambda feat: feat["image"]))
-    train = plot_examples(dataset.map(lambda feat: map_fn(feat, training=True)[0]))
-    eval = plot_examples(dataset.map(lambda feat: map_fn(feat)[0]))
+def plot_all_examples(set):
+    dataset = set.load_split(set.train_split, shuffle=False)
+    decoder = set.info.features["image"].decode_example
+
+    raw = plot_examples(dataset.map(lambda feat: decoder(feat["image"])))
+    train = plot_examples(dataset.map(lambda feat: set.map_fn(feat, training=True)[0]))
+    eval = plot_examples(dataset.map(lambda feat: set.map_fn(feat)[0]))
     return raw, train, eval

--- a/zookeeper/registry.py
+++ b/zookeeper/registry.py
@@ -93,7 +93,12 @@ def register_hparams(model):
 
 
 def get_dataset(
-    dataset_name, preprocess_name, use_val_split=False, cache_dir=None, data_dir=None
+    dataset_name,
+    preprocess_name,
+    use_val_split=False,
+    cache_dir=None,
+    version=None,
+    data_dir=None,
 ):
     if dataset_name not in DATA_REGISTRY:
         raise DatasetNotFoundError(dataset_name)
@@ -107,6 +112,7 @@ def get_dataset(
         use_val_split=use_val_split,
         cache_dir=cache_dir,
         data_dir=data_dir,
+        version=version,
     )
 
 


### PR DESCRIPTION
This PR moves us to `tensorflow-datasets==1.1.0`. This means we can now make a few improvements related to make the input pipeline more reliable and faster.
The main changes are:
- Remove experimental options (they will be enabled by default if we use the new S3 datasets e.g. `imagenet2012:5.0.0`.
- Reduce final prefetch to 1 batch, which should be enough for the current use cases and drastically reduces memory consumption
- Shuffle and cache before image decoding. This should reduce memory consumption of the shuffle and reduce the disk size needed when caching datasets. See https://github.com/tensorflow/datasets/blob/master/docs/decode.md
- Add support for dataset version using a `--dataset-version` option. See https://github.com/tensorflow/datasets/blob/master/docs/datasets_versioning.md

There are a few things that could still be improved:
- Use the fused ops for [decoding and cropping](https://github.com/tensorflow/datasets/blob/master/docs/decode.md#cropping-and-decoding-at-the-same-time) to speedup ImageNet preprocessing.
- Add support for the new slicing API: https://github.com/tensorflow/datasets/blob/master/docs/splits.md#s3-slicing-api