### PR TITLE
Support preprocess functions that expect bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ import tensorflow as tf
 from zookeeper import cli, build_train, HParams, registry
 
 @registry.register_preprocess("mnist")
-def default(image, training=False):
-    return tf.cast(image, dtype=tf.float32) / 255
+def default(image_tensor, training=False):
+    return tf.cast(image_tensor, dtype=tf.float32) / 255
 ```
 
 #### Models

--- a/examples/train.py
+++ b/examples/train.py
@@ -3,8 +3,8 @@ import tensorflow as tf
 
 
 @registry.register_preprocess("mnist")
-def default(image):
-    return tf.cast(image, dtype=tf.float32) / 255
+def default(image_tensor):
+    return tf.cast(image_tensor, dtype=tf.float32) / 255
 
 
 @registry.register_model

--- a/zookeeper/cli_test.py
+++ b/zookeeper/cli_test.py
@@ -7,13 +7,13 @@ import tensorflow as tf
 
 
 @registry.register_preprocess("mnist")
-def default(image):
-    return image
+def default(image_tensor):
+    return image_tensor
 
 
 @registry.register_preprocess("mnist")
-def raw(bytes):
-    return tf.image.decode_image(bytes)
+def raw(image_bytes):
+    return tf.image.decode_image(image_bytes)
 
 
 @registry.register_model

--- a/zookeeper/cli_test.py
+++ b/zookeeper/cli_test.py
@@ -3,11 +3,17 @@ from click.testing import CliRunner
 import click
 from unittest import mock
 from os import path
+import tensorflow as tf
 
 
 @registry.register_preprocess("mnist")
 def default(image):
     return image
+
+
+@registry.register_preprocess("mnist")
+def raw(bytes):
+    return tf.image.decode_image(bytes)
 
 
 @registry.register_model
@@ -96,6 +102,8 @@ def test_cli(tmp_path):
             "--dataset",
             "mnist",
             "--validationset",
+            "--preprocess-fn",
+            "raw",
         ],
     )
     assert result.exit_code == 0

--- a/zookeeper/data.py
+++ b/zookeeper/data.py
@@ -75,7 +75,7 @@ class Dataset:
         args = inspect.getfullargspec(self.preprocess_fn).args
         image_or_bytes = (
             data["image"]
-            if "bytes" in args
+            if "image_bytes" == args[0]
             else self.info.features["image"].decode_example(data["image"])
         )
         if "training" in args:


### PR DESCRIPTION
This allows us to directly proccess raw image bytes in the preprocess function. This can be use for compatibility with external preprocessing implementations or for speed in order to use fused decode and crop implementations.

The following functions will now produce the same output:
```python
@registry.register_preprocess("mnist")
def default(image):
    return image

@registry.register_preprocess("mnist")
def raw(bytes):
    return tf.image.decode_image(bytes)
```

Note: Once we start using zookeeper for application other than image classification, we need to make this more general, but for now let's keep it simple.