### PR TITLE
Pass data_dir to builder

### DIFF
--- a/zookeeper/data.py
+++ b/zookeeper/data.py
@@ -20,7 +20,7 @@ class Dataset:
         self.cache_dir = cache_dir
         self.version = version
 
-        self.info = tfds.builder(self.dataset_name_str).info
+        self.info = tfds.builder(self.dataset_name_str, data_dir=data_dir).info
         splits = self.info.splits
         self.preprocessing = preprocess_cls(features=self.info.features)
 


### PR DESCRIPTION
This allows us to use datasets that are not available in the upstream version of `tensorflow/datasets`.