### PR TITLE
Correctly pass is_training to preprocess functions

### DIFF
--- a/zookeeper/preprocessing.py
+++ b/zookeeper/preprocessing.py
@@ -67,6 +67,6 @@ class Preprocessing:
         # Returns
         A tuple of (inputs, outputs)
         """
-        input_fn = pass_training_kwarg(self.inputs)
-        output_fn = pass_training_kwarg(self.outputs)
+        input_fn = pass_training_kwarg(self.inputs, training=training)
+        output_fn = pass_training_kwarg(self.outputs, training=training)
         return input_fn(data), output_fn(data)

--- a/zookeeper/preprocessing_test.py
+++ b/zookeeper/preprocessing_test.py
@@ -1,0 +1,40 @@
+from zookeeper import Preprocessing
+from unittest.mock import Mock
+
+
+class PreprocessingSimple(Preprocessing):
+    def inputs(self, data):
+        pass
+
+    def outputs(self, data):
+        pass
+
+
+class PreprocessingWithTraining(Preprocessing):
+    _assert_training = False
+
+    def inputs(self, data, training):
+        assert training == self._assert_training
+
+    def outputs(self, data, training):
+        assert training == self._assert_training
+
+
+def test_preprocessing_without_training_arg():
+    prepro = PreprocessingSimple()
+    prepro.inputs = Mock()
+    prepro.outputs = Mock()
+
+    prepro("data")
+    prepro.inputs.assert_called_with("data")
+    prepro.outputs.assert_called_with("data")
+
+
+def test_preprocessing_with_training_arg():
+    prepro = PreprocessingWithTraining()
+
+    assert prepro._assert_training == False
+    prepro("data", training=False)
+
+    prepro._assert_training = True
+    prepro("data", training=True)


### PR DESCRIPTION
This bug was introduced in #41

@koenhelwegen Thanks for catching that.