### PR TITLE
Add support for passing a dataset name to Preprocessing class

### DIFF
--- a/zookeeper/data.py
+++ b/zookeeper/data.py
@@ -22,7 +22,9 @@ class Dataset:
 
         self.info = tfds.builder(self.dataset_name_str, data_dir=data_dir).info
         splits = self.info.splits
-        self.preprocessing = preprocess_cls(features=self.info.features, dataset_name=self.dataset_name)
+        self.preprocessing = preprocess_cls(
+            features=self.info.features, dataset_name=self.dataset_name
+        )
 
         if tfds.Split.TRAIN not in splits:
             raise ValueError("To train we require a train split in the dataset.")

--- a/zookeeper/data.py
+++ b/zookeeper/data.py
@@ -22,7 +22,7 @@ class Dataset:
 
         self.info = tfds.builder(self.dataset_name_str, data_dir=data_dir).info
         splits = self.info.splits
-        self.preprocessing = preprocess_cls(features=self.info.features)
+        self.preprocessing = preprocess_cls(features=self.info.features, dataset_name=self.dataset_name)
 
         if tfds.Split.TRAIN not in splits:
             raise ValueError("To train we require a train split in the dataset.")

--- a/zookeeper/preprocessing.py
+++ b/zookeeper/preprocessing.py
@@ -19,6 +19,7 @@ class Preprocessing:
 
     # Arguments
     features: A [`tfds.features.FeaturesDict`](https://www.tensorflow.org/datasets/api_docs/python/tfds/features/FeaturesDict)
+    dataset_name: Optional `str` name of the dataset this class will be applied to. Useful for re-using the same Preprocessing class for different datasets with slight differences.
 
     # Properties
     - `decoders`: Nested `dict` of [`Decoder`](https://www.tensorflow.org/datasets/api_docs/python/tfds/decode/Decoder)
@@ -32,8 +33,9 @@ class Preprocessing:
     decoders = None
     kwargs = {}
 
-    def __init__(self, features=None):
+    def __init__(self, features=None, dataset_name=None):
         self.features = features
+        self.dataset_name = dataset_name
 
     def inputs(self, data, training):
         """A method to define preprocessing for inputs.

--- a/zookeeper/preprocessing_test.py
+++ b/zookeeper/preprocessing_test.py
@@ -21,7 +21,9 @@ class PreprocessingWithTraining(Preprocessing):
 
 
 def test_preprocessing_without_training_arg():
-    prepro = PreprocessingSimple()
+    prepro = PreprocessingSimple(dataset_name="test_name")
+    assert prepro.dataset_name == "test_name"
+
     prepro.inputs = Mock()
     prepro.outputs = Mock()
 


### PR DESCRIPTION
This is useful in cases where the same preprocessing is to be used for different datasets, but slight differences are necessary depending on which dataset is used. Rather than defining a new pre-processing class for each dataset, you can just re-use the same one and implement the appropriate logic.