### PR TITLE
Support hidden parameters in HParams

### DIFF
--- a/zookeeper/hparam.py
+++ b/zookeeper/hparam.py
@@ -57,6 +57,7 @@ class HParams(collections.abc.Mapping):
     """
 
     _abc_methods = {"get", "items", "keys", "parse", "values"}
+    _hidden_attributes = {}
 
     def __init__(self, **kwargs):
         """Optionally use `kwargs` to override or set new hyperparameter values."""
@@ -100,8 +101,15 @@ class HParams(collections.abc.Mapping):
     def _is_hparam(self, item):
         return item not in self._abc_methods and not item.startswith("_")
 
-    def __iter__(self):
-        return (item for item in self.__dir__() if self._is_hparam(item))
+    def __iter__(self, return_hidden=False):
+        """Prevent the ** operator from returning hidden properties, 
+        unless otherwise specified"""
+        return (
+            item
+            for item in self.__dir__()
+            if self._is_hparam(item)
+            and (return_hidden or not item in self._hidden_attributes)
+        )
 
     def __getitem__(self, item):
         try:

--- a/zookeeper/hparam_test.py
+++ b/zookeeper/hparam_test.py
@@ -10,6 +10,9 @@ class Hyper(HParams):
     bar = 0.5
     baz = "string"
 
+    hidden = "hidden_value"
+    _hidden_attributes = {"hidden"}
+
     @property
     def barx2(self):
         return self.bar * 2
@@ -130,3 +133,9 @@ def test_init_kwargs(hyper):
         new_hyper = Hyper(_new_name="new_value")
     with pytest.raises(ValueError):
         new_hyper = Hyper(parse=lambda x: x ** 2)
+
+
+def test_unpacking(hyper):
+    assert hyper.hidden == "hidden_value"
+    items = [item for item in hyper]
+    assert "hidden" not in items


### PR DESCRIPTION
Adds a way to add properties to a HParams object that can be accessed directly, but won't show up when unpacking the object. For example:

```python
class Hyper(HParams):
    filters=32
    kernel_size = (3, 3)
    hidden = "hidden_value"
    _hidden_attributes = {"hidden"}

def test_hyper():
    hp = Hyper()
    layer = tf.keras.layers.Conv2D(**hyper)

    if hp.hidden == "hidden_value":
         # Perform some action
         pass
```
Without specifying `hidden` in `_hidden_attributes`, this code would break, as tf.keras.layers.Conv2D doesn't accept a `hidden` keyword argument.

Ideally, we'd mark hidden attributes with a decorator rather than adding them to _hidden_attributes manually, see #53 . However, this would require some fairly significant changes to the HParams class.