### PR TITLE
Throw more meaningful AttributeError

### DIFF
--- a/zookeeper/component.py
+++ b/zookeeper/component.py
@@ -181,7 +181,7 @@ class Component:
         if name in self.__component_annotations__ and self.__component_parent__:
             return getattr(self.__component_parent__, name)
         raise AttributeError(
-            f"Component {self.__class__.__name__} does not have any attribute {name}."
+            f"Component {self.__component_name__} does not have any attribute {name}."
         )
 
     def __setattr__(self, name, value):

--- a/zookeeper/component.py
+++ b/zookeeper/component.py
@@ -180,7 +180,9 @@ class Component:
         # parent if possible.
         if name in self.__component_annotations__ and self.__component_parent__:
             return getattr(self.__component_parent__, name)
-        raise AttributeError
+        raise AttributeError(
+            f"Component {self.__class__.__name__} does not have any attribute {name}."
+        )
 
     def __setattr__(self, name, value):
         # Type-check annotated values.


### PR DESCRIPTION
Currently, zookeeper just throws `AttributeError` when a nonexistent attribute is accessed. This gives a bit more info.