### PR TITLE
Allow paths to be passed through the CLI, and add CLI tests.

### DIFF
--- a/zookeeper/cli.py
+++ b/zookeeper/cli.py
@@ -21,8 +21,8 @@ class ConfigParam(click.ParamType):
         except Exception:
             self.fail(
                 "configuration parameters must be of the form 'key=value', where "
-                "the key contains only alpha-numeric characters, underscores, and "
-                f"full-stops, but received '{str_value}'.",
+                "the key contains only alpha-numeric characters, '_', and '.', "
+                f"and the value doesn't contain '='. Received '{str_value}'.",
                 param,
                 ctx,
             )

--- a/zookeeper/cli_test.py
+++ b/zookeeper/cli_test.py
@@ -1,0 +1,63 @@
+import pytest
+from click.testing import CliRunner
+
+from zookeeper import Task
+from zookeeper.cli import add_task_to_cli, cli
+
+
+@pytest.fixture
+def test_task():
+    # We have to define `TestTask` inside a pytest fixture so that it gets
+    # reinstantiated for every test.
+
+    @add_task_to_cli
+    class TestTask(Task):
+        a: int
+        b: str = "foo"
+
+        def run(self):
+            print(self.a, self.b)
+
+    return None
+
+
+runner = CliRunner(mix_stderr=False)
+
+
+def test_pass_param_values(test_task):
+    # We should be able to pass parameter values through the CLI.
+    result = runner.invoke(cli, ["test_task", "a=5"])
+    assert result.exit_code == 0
+    assert result.output == "5 foo\n"
+
+
+def test_param_key_valid_characters(test_task):
+    # We should be able to pass keys with underscores and full stops and
+    # capitals. It's okay here that the param with name `x.y_z.A` doesn't
+    # actually exist.
+    result = runner.invoke(cli, ["test_task", "a=5", "x.y_z.A=1.0"])
+    assert result.exit_code == 0
+
+
+def test_param_key_invalid_characters(test_task):
+    # Keys with invalid characters such as '-' or '@' should not be accepted.
+    result = runner.invoke(cli, ["test_task", "a=5", "x-y=1.0"])
+    assert result.exit_code == 2
+    result = runner.invoke(cli, ["test_task", "a=5", "x@y=1.0"])
+    assert result.exit_code == 2
+
+
+def test_override_param_values(test_task):
+    # We should be able to override existing parameter values through the CLI.
+    result = runner.invoke(cli, ["test_task", "a=5", "b=bar"])
+    assert result.exit_code == 0
+    assert result.output == "5 bar\n"
+
+
+def test_override_param_complex_string(test_task):
+    # We should be able to pass complex strings, including paths.
+    result = runner.invoke(
+        cli, ["test_task", "a=5", "b=https://some-path/foo/bar@somewhere"]
+    )
+    assert result.exit_code == 0
+    assert result.output == "5 https://some-path/foo/bar@somewhere\n"

--- a/zookeeper/utils.py
+++ b/zookeeper/utils.py
@@ -24,9 +24,8 @@ def get_concrete_subclasses(cls) -> Set[type]:
 def parse_value_from_string(string: str):
     try:
         value = literal_eval(string)
-    except ValueError:
-        # Parse as string if above raises ValueError. Note that
-        # syntax errors will still raise an error.
+    except (ValueError, SyntaxError):
+        # Parse as string if above raises a ValueError or SyntaxError.
         value = str(string)
     except Exception:
         raise ValueError(f"Could not parse '{string}'.")


### PR DESCRIPTION
Previously, it was not possible to pass paths (which included colons ':') through the CLI because `ast.literal_eval` threw a `SyntaxError` instead of a `ValueError`.