### PR TITLE
Fix tfds import

### DIFF
--- a/zookeeper/tf/preprocessing.py
+++ b/zookeeper/tf/preprocessing.py
@@ -15,7 +15,7 @@ def pass_training_kwarg(function, training=False):
 class Preprocessing:
     """A wrapper around `tf.data` preprocessing."""
 
-    decoders: Dict[str, tfds.core.base.Decoder] = None
+    decoders: Dict[str, tfds.decode.Decoder] = None
 
     # The shape of the processed input. Must match the output of `input()`.
     input_shape: Tuple[int, int, int]


### PR DESCRIPTION
With `tfds==1.3.2` the example would fail with `AttributeError: module 'tensorflow_datasets.core' has no attribute 'base'`