### PR TITLE
Change component colouring in __repr__

### DIFF
--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -85,9 +85,9 @@ from zookeeper.core.utils import (
 try:  # pragma: no cover
     from colorama import Fore
 
-    YELLOW, GREEN, RED, RESET = Fore.YELLOW, Fore.GREEN, Fore.RED, Fore.RESET
+    BLUE, RESET, YELLOW = Fore.BLUE, Fore.RESET, Fore.YELLOW
 except ImportError:  # pragma: no cover
-    YELLOW = GREEN = RED = RESET = ""
+    BLUE = RESET = YELLOW = ""
 
 
 def is_component_class(cls):
@@ -301,12 +301,7 @@ def str_key_val(key, value, color=True, single_line=False):
         value = "<callable>"
     elif type(value) == str:
         value = f'"{value}"'
-    space = "" if single_line else " "
-    return (
-        f"{YELLOW}{key}{RESET}{space}={space}{YELLOW}{value}{RESET}"
-        if color
-        else f"{key}{space}={space}{value}"
-    )
+    return f"{BLUE}{key}{RESET}={YELLOW}{value}{RESET}" if color else f"{key}={value}"
 
 
 def __component_repr__(instance):

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -323,11 +323,11 @@ def test_str_and_repr():
     assert (
         unstyle(str(p))
         == """Parent(
-    b = "foo",
-    child = Child(
-        a = 10,
-        b = "foo",
-        c = [1.5, -1.2]
+    b="foo",
+    child=Child(
+        a=10,
+        b="foo",
+        c=[1.5, -1.2]
     )
 )"""
     )


### PR DESCRIPTION
This PR slightly changes the coloured string representation. It removes the spacing for the keyword arguments and makes the printing multicolour:

## master
<img width="1552" alt="Screenshot 2020-01-06 at 10 59 17" src="https://user-images.githubusercontent.com/13285808/71811447-ff8d2080-3074-11ea-98d0-bdbf3d4650cb.png">

## PR
<img width="1552" alt="Screenshot 2020-01-06 at 11 05 02" src="https://user-images.githubusercontent.com/13285808/71811449-0025b700-3075-11ea-95d3-915094fbcbe0.png">
