### PR TITLE
Add should_cache flag to TFDSDataset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "prompt-toolkit>=2.0.10",
         "tensorflow-datasets>=1.3.0",
         "typeguard>=2.5.1",
+        "psutil>=5.0.0"
     ],
     extras_require={
         "tensorflow": ["tensorflow>=1.14.0"],


### PR DESCRIPTION
This flag can be used in userspace to define behaviour of dataset caching. The flag is enabled by default on small datasets depending on their memory requirements.

I am not completely sure if `should_cache` is the correct name or if `is_cachable` is better, since the flag actually doesn't do anything right now.