### PR TITLE
Remove metrics, learning_rate_schedule and callbacks from experiment class

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{matrix.python-version}}
+      - name: Fix tfds for TF 1.x
+        run: pip install tensorflow_datasets==1.3.*
+        if: matrix.tf-version == '1.14.0' 
       - name: Install dependencies
         run: |
           pip install tensorflow==${{matrix.tf-version}}

--- a/examples/larq_experiment.py
+++ b/examples/larq_experiment.py
@@ -149,7 +149,6 @@ class BinaryNetMnist(Experiment):
             steps_per_epoch=num_train_examples // self.batch_size,
             validation_data=validation_data,
             validation_steps=num_validation_examples // self.batch_size,
-            callbacks=self.callbacks,
         )
 
 

--- a/zookeeper/tf/experiment.py
+++ b/zookeeper/tf/experiment.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Optional, Union
+from typing import Optional, Union
 
 from tensorflow import keras
 

--- a/zookeeper/tf/experiment.py
+++ b/zookeeper/tf/experiment.py
@@ -21,8 +21,5 @@ class Experiment:
     # Parameters
     epochs: int
     batch_size: int
-    metrics: List[Union[keras.metrics.Metric, Callable, str]] = []
     loss: Optional[Union[keras.losses.Loss, str]]
     optimizer: Union[keras.optimizers.Optimizer, str]
-    learning_rate_schedule: Optional[Callable] = None
-    callbacks: List[Union[keras.callbacks.Callback, Callable]] = []


### PR DESCRIPTION
Unfortunately there is no way to lazily compute `callbacks` if it is a CLI overwritable attribute, so let's remove everything that in practice won't be overwritten from the CLI