### PR TITLE
Make component fields explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ pip install zookeeper
 
 The fundamental building blocks of Zookeeper are components. The
 [`@component`](zookeeper/component.py) decorator is used to turn classes into
-components. These component classes can have configurable parameters, which are
-declared using class-level type annotations (in a similar way to [Python
-dataclasses](https://docs.python.org/3/library/dataclasses.html)). These
-parameters can be Python objects or nested sub-components, and need not be set
-with a default value.
+components. These component classes can have configurable fields, which are
+declared with the `Field` constructor and class-level type annotations. Fields
+can be created with or without default values. Components can also be nested,
+with `ComponentField`s, such that child componenents can access the field values
+defined on their parents.
 
 For example:
 
@@ -27,22 +27,22 @@ from zookeeper import component
 
 @component
 class ChildComponent:
-    a: int                  # An `int` parameter, with no default set
-    b: str = "foo"          # A `str` parameter, which by default will be `foo`
+    a: int = Field()                          # An `int` field with no default set
+    b: str = Field("foo")                     # A `str` field with default value `"foo"`
 
 @component
 class ParentComponent:
-    a: int                  # The same `int` parameter as the child
-    child: ChildComponent   # A nested component parameter, of type `ChildComponent`
+    a: int = Field()                          # The same `int` field as the child
+    child: ChildComponent = ComponentField()  # A nested component field, of type `ChildComponent`
 ```
 
 After instantiation, components can be 'configured' with a configuration
-dictionary, containing values for a tree of nested parameters. This process
-automatically injects the correct values into each parameter.
+dictionary, containing values for a tree of nested fields. This process
+automatically injects the correct values into each field.
 
-If a child sub-component declares a parameter which already exists in some
-containing parent, then it will pick up the value that's set on the parent,
-unless a 'scoped' value is set on the child.
+If a child sub-component declares a field which already exists in some
+containing ancestor component, then it will pick up the value that's set on the
+parent, unless a 'scoped' value is set on the child.
 
 For example:
 
@@ -88,7 +88,7 @@ from zookeeper import cli, task
 
 @task
 class UseChildA:
-    parent: ParentComponent
+    parent: ParentComponent = ComponentField()
     def run(self):
         print(self.parent.child.a)
 

--- a/examples/larq_experiment.py
+++ b/examples/larq_experiment.py
@@ -104,19 +104,15 @@ class BinaryNet(Model):
 @task
 class BinaryNetMnist(Experiment):
     dataset = ComponentField(Mnist)
-    preprocessing = ComponentField(
-        PadCropAndFlip, pad_size=32, input_shape=lambda: (28, 28, 1)
-    )
+    preprocessing = ComponentField(PadCropAndFlip, pad_size=32, input_shape=(28, 28, 1))
     model = ComponentField(BinaryNet)
 
     epochs = Field(100)
     batch_size = Field(128)
+    learning_rate: float = Field(5e-3)
 
     loss = Field("sparse_categorical_crossentropy")
-
     metrics: Sequence[str] = Field(lambda: ["accuracy"])
-
-    learning_rate: float = Field(5e-3)
 
     @Field
     def optimizer(self):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="zookeeper",
     version="1.0.b4",
     author="Plumerai",
-    author_email="lukas@plumerai.co.uk",
+    author_email="lukas@plumerai.com, adamh@plumerai.com",
     description="A small library for managing deep learning models, hyper parameters and datasets",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/zookeeper/__init__.py
+++ b/zookeeper/__init__.py
@@ -1,3 +1,19 @@
-from zookeeper.core import cli, component, configure, task
+from zookeeper.core import (
+    ComponentField,
+    Field,
+    PartialComponent,
+    cli,
+    component,
+    configure,
+    task,
+)
 
-__all__ = ["cli", "component", "configure", "task"]
+__all__ = [
+    "cli",
+    "ComponentField",
+    "component",
+    "configure",
+    "Field",
+    "PartialComponent",
+    "task",
+]

--- a/zookeeper/core/__init__.py
+++ b/zookeeper/core/__init__.py
@@ -1,5 +1,15 @@
 from zookeeper.core.cli import cli
 from zookeeper.core.component import component, configure
+from zookeeper.core.field import ComponentField, Field
+from zookeeper.core.partial_component import PartialComponent
 from zookeeper.core.task import task
 
-__all__ = ["component", "configure", "cli", "task"]
+__all__ = [
+    "component",
+    "ComponentField",
+    "configure",
+    "cli",
+    "Field",
+    "PartialComponent",
+    "task",
+]

--- a/zookeeper/core/cli_test.py
+++ b/zookeeper/core/cli_test.py
@@ -1,14 +1,15 @@
 from click import testing
 
 from zookeeper.core.cli import cli
+from zookeeper.core.field import Field
 from zookeeper.core.task import task
 
 
 @task
 class TestTask:
-    a: int
-    b: str = "foo"
-    c: bool = False
+    a: int = Field()
+    b: str = Field("foo")
+    c: bool = Field(False)
 
     def run(self):
         print(self.a, self.b, self.c)

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -360,6 +360,20 @@ def component(cls):
             f"WARNING: Component {cls.__name__} has no defined fields."
         )
 
+    # Throw an error if there is a field defined on a superclass that has been
+    # overriden with a non-Field value.
+    for name in dir(cls):
+        if name in fields and not isinstance(getattr(cls, name), Field):
+            super_class = fields[name].host_component_class
+            raise ValueError(
+                f"Field '{name}' is defined on super-class {super_class.__name__}. "
+                f"In subclass {cls.__name__}, '{name}' has been overriden with value: "
+                f"{getattr(cls, name)}.\n\n"
+                f"If you wish to change the default value of field '{name}' in a "
+                f"subclass of {super_class.__name__}, please wrap the new default "
+                "value in a new `Field` instance."
+            )
+
     cls.__component_fields__ = fields
 
     # Override class methods to correctly interact with component fields.

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -71,7 +71,7 @@ print(c)
 
 import functools
 import inspect
-from typing import Any, Dict, Optional, Set, Type
+from typing import Any, Dict, List, Optional, Type
 
 from prompt_toolkit import print_formatted_text
 from typeguard import check_type
@@ -230,8 +230,8 @@ def _wrap_dir(component_cls: Type) -> None:
     fn = component_cls.__dir__  # type: ignore
 
     @functools.wraps(fn)
-    def wrapped_fn(instance) -> Set[str]:
-        return set(fn(instance)) | set(instance.__component_fields__.keys())
+    def wrapped_fn(instance) -> List[str]:
+        return list(set(fn(instance)) | set(instance.__component_fields__.keys()))
 
     component_cls.__dir__ = wrapped_fn
 
@@ -354,7 +354,12 @@ def component(cls):
         for name, value in base_class.__dict__.items():
             if isinstance(value, Field):
                 fields[name] = value
-    # TODO: maybe throw/warn if no fields defined?
+
+    if len(fields) == 0:
+        utils.print_formatted_text(
+            f"WARNING: Component {cls.__name__} has no defined fields."
+        )
+
     cls.__component_fields__ = fields
 
     # Override class methods to correctly interact with component fields.

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -26,19 +26,19 @@ configuration scoping:
 ```
 @component
 class A:
-    x: int
-    z: float
+    x: int = Field()
+    z: float = Field()
 
 @component
 class B:
-    a: A
-    y: str = "foo"
+    a: A = Field()
+    y: str = Field("foo")
 
 @component
 class C:
-    b: B
-    x: int
-    z: float = 3.14
+    b: B = Field()
+    x: int = Field()
+    z: float = Field(3.14)
 
 c = C()
 configure(
@@ -69,304 +69,308 @@ print(c)
 ```
 """
 
+import functools
 import inspect
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set, Type
 
 from prompt_toolkit import print_formatted_text
 from typeguard import check_type
 
-from zookeeper.core.utils import (
-    convert_to_snake_case,
-    prompt_for_component_subclass,
-    prompt_for_value,
-    type_name_str,
-)
+from zookeeper.core import utils
+from zookeeper.core.field import ComponentField, Field
 
 try:  # pragma: no cover
-    from colorama import Fore
+    from colorama import Fore, Style
 
-    BLUE, RESET, YELLOW = Fore.BLUE, Fore.RESET, Fore.YELLOW
+    RED, YELLOW = Fore.RED, Fore.YELLOW
+    BRIGHT, RESET_ALL = Style.BRIGHT, Style.RESET_ALL
 except ImportError:  # pragma: no cover
-    BLUE = RESET = YELLOW = ""
+    BRIGHT = RED = RESET_ALL = YELLOW = ""
 
 
-def is_component_class(cls):
+###################################
+# Component class method wrappers #
+###################################
+
+
+def _type_check_and_cache(instance, field: Field, result: Any) -> None:
+    """A utility method for `_wrap_getattribute`."""
+
     try:
-        return "__component_name__" in cls.__dict__
-    except AttributeError:
-        return False
+        check_type(field.name, result, field.type)
+    except TypeError:
+        raise TypeError(
+            f"Field '{field.name}' of component '{instance.__component_name__}' is "
+            f"annotated with type '{field.type}', which is not satisfied by "
+            f"default value {result}."
+        ) from None
+    object.__setattr__(instance, field.name, result)
 
 
-def generate_subclasses(cls):
-    """Recursively find subclasses of `cls`."""
+def _wrap_getattribute(component_cls: Type) -> None:
+    """
+    The logic for this overriden `__getattribute__` is as follows:
 
-    if not inspect.isclass(cls):
-        return
-    yield cls
-    for s in cls.__subclasses__():
-        yield from generate_subclasses(s)
+    During component instantiation, any values passed to `__init__` are stored
+    in a dict on the instance `__component_instantiated_field_values__`. This
+    means that a priori the `__dict__` of a component instance is empty (of
+    non-dunder attributes).
 
+    Field values can come from three sources, in descending order of priority:
+      1) A value that was passed into `configure` (e.g. via the CLI), which is
+         stored in the `__component_configured_field_values__` dict on the
+         component instance or some parent component instance.
+      2) A value that was passed in at instantiation, which is stored in the
+         `__component_instantiated_field_values__` dict on the current component
+         instance (but not any parent instance).
+      3) A default value obtained from the `get_default` factory method of a
+         field defined on the component class of the current instance if it has
+         one, or otherwise from the factory of the field on the component class
+         of the nearest parent component instance with a field of the same name,
+         et cetera.
 
-def generate_component_subclasses(cls):
-    """Find component subclasses of `cls`."""
+    Once we find a field value from one of these three sources, we set the value
+    on the instance `__dict__` (i.e. we 'cache' it).
 
-    for subclass in generate_subclasses(cls):
-        if is_component_class(subclass) and not inspect.isabstract(subclass):
-            yield subclass
+    This means that if we find a value in the instance `__dict__` we can
+    immediately return it without worrying about checking the three cases above
+    in order. It also means that each look-up other than the first will incur no
+    substantial time penalty.
+    """
+    fn = component_cls.__getattribute__  # type: ignore
 
+    @functools.wraps(fn)
+    def wrapped_fn(instance, name):
+        # If this is not an access to a field, return via the wrapped function.
+        if name not in fn(instance, "__component_fields__"):
+            return fn(instance, name)
 
-#####################
-# Component fields. #
-#####################
+        # If there is a cached value, return it immediately.
+        if name in instance.__dict__:
+            return instance.__dict__[name]
 
+        field = instance.__component_fields__[name]
 
-class Field:
-    def __init__(self, annotated_type):
-        self.annotated_type = annotated_type
-
-
-class EmptyField(Field):
-    pass
-
-
-class InheritedField(Field):
-    def __init__(self, annotated_type, is_overriden=False):
-        super().__init__(annotated_type)
-        self.is_overriden = is_overriden
-
-
-class NonEmptyField(Field):
-    def __init__(self, annotated_type, is_overriden):
-        super().__init__(annotated_type)
-        self.is_overriden = is_overriden
-
-
-class EmptyFieldError(AttributeError):
-    def __init__(self, component, field_name):
-        message = (
-            f"The component `{component.__component_name__}` has no default or "
-            f"configured value for field `{field_name}`. Please configure the "
-            "component to provide a value."
-        )
-        super().__init__(message)
-
-
-# Constants which are used internally during component configuration. They are
-# used as placeholders to indicate to a nested sub-component that an ancestor
-# component has a value for a given field name.
-OVERRIDEN_CONF_VALUE = object()
-NON_OVERRIDEN_CONF_VALUE = object()
-
-
-def set_field_value(instance, name, value):
-    assert not instance.__component_configured__
-    assert name in instance.__component_fields__
-    field = instance.__component_fields__[name]
-
-    if value == OVERRIDEN_CONF_VALUE:
-        instance.__component_fields__[name] = InheritedField(
-            annotated_type=field.annotated_type, is_overriden=True
-        )
-    elif value == NON_OVERRIDEN_CONF_VALUE:
-        if isinstance(field, EmptyField):
-            instance.__component_fields__[name] = InheritedField(
-                annotated_type=field.annotated_type, is_overriden=False
-            )
-    else:
-        object.__setattr__(instance, name, value)
-        instance.__component_fields__[name] = NonEmptyField(
-            annotated_type=field.annotated_type, is_overriden=False
-        )
-
-
-####################################
-# Component class method wrappers. #
-####################################
-
-
-def init_wrapper(init_fn):
-    # Components need to be instantiable without arguments, so check that
-    # `init_fn` does not accept any positional arguments without default values.
-    for i, (name, param) in enumerate(inspect.signature(init_fn).parameters.items()):
-        if (
-            i > 0
-            and param.default == inspect.Parameter.empty
-            and param.kind
-            not in [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD]
+        # Next, try Source 1)
+        for ancestor_with_field in utils.generate_component_ancestors_with_field(
+            instance, field_name=name, include_instance=True
         ):
-            raise ValueError(
-                "The `__init__` method of a component must not accept any "
-                "positional arguments, as the component configuration process "
-                "requires component classes to be instantiable without arguments."
+            if name in ancestor_with_field.__component_configured_field_values__:
+                result = ancestor_with_field.__component_configured_field_values__[name]
+                # Type-check, cache the result, delete it if possible from the
+                # instantiated values, and return it.
+                _type_check_and_cache(instance, field, result)
+                if name in instance.__component_instantiated_field_values__:
+                    del instance.__component_instantiated_field_values__[name]
+                return result
+
+        # Next, try Source 2)
+        if name in instance.__component_instantiated_field_values__:
+            # Type-check, cache, and return the result.
+            result = instance.__component_instantiated_field_values__[name]
+            _type_check_and_cache(instance, field, result)
+            return result
+
+        # Finally, try Source 3)
+        try:
+            result = field.get_default(instance)
+        except AttributeError as e:
+            # Find the closest parent with a field of the same name, and
+            # recurse.
+            parent_instance = next(
+                utils.generate_component_ancestors_with_field(instance, name), None
             )
+            try:
+                result = getattr(parent_instance, name)
+            except AttributeError:
+                # From here we raise the original exception instead because it
+                # will correctly refer to this component rather than some parent
+                # component.
+                raise e from None
 
-    def __component_init__(instance, **kwargs):
-        # Fake 'super' call.
-        if init_fn != object.__init__:
-            init_fn(instance, **kwargs)
+        # Type-check, cache, and return the result.
+        _type_check_and_cache(instance, field, result)
+        return result
 
-        instance.__component_fields__ = {}
+    component_cls.__getattribute__ = wrapped_fn
 
-        # Populate `__component_fields__` with all annotations set on this class
-        # and all superclasses. We have to go through the MRO chain and collect
-        # them in reverse order so that they are correctly overriden.
-        annotations = {}
-        for base_class in reversed(inspect.getmro(instance.__class__)):
-            annotations.update(getattr(base_class, "__annotations__", {}))
-        instance.__component_fields__ = {}
-        for name, annotated_type in annotations.items():
-            if name in object.__dir__(instance):  # type: ignore
-                instance.__component_fields__[name] = NonEmptyField(
-                    annotated_type, is_overriden=False
+
+def _wrap_setattr(component_cls: Type) -> None:
+    fn = component_cls.__setattr__  # type: ignore
+
+    @functools.wraps(fn)
+    def wrapped_fn(instance, name, value):
+        try:
+            value_defined_on_class = getattr(component_cls, name)
+            if isinstance(value_defined_on_class, Field):
+                raise ValueError(
+                    "Setting component field values directly is prohibited. Use "
+                    "Zookeeper component configuration to set field values."
                 )
-            else:
-                instance.__component_fields__[name] = EmptyField(annotated_type)
+        except AttributeError:
+            pass
+        return fn(instance, name, value)
 
-        if init_fn == object.__init__:
-            for name, value in kwargs.items():
-                if name in instance.__component_fields__:
-                    set_field_value(instance, name, value)
-                else:
-                    raise ValueError(
-                        f"Argument '{name}' does not correspond to any annotated field "
-                        f"of '{type_name_str(instance.__class__)}'."
-                    )
-
-    return __component_init__
+    component_cls.__setattr__ = wrapped_fn
 
 
-def dir_wrapper(dir_fn):
-    def __component_dir__(instance):
-        return set(dir_fn(instance)) | set(instance.__component_fields__.keys())
+def _wrap_delattr(component_cls: Type) -> None:
+    fn = component_cls.__delattr__  # type: ignore
 
-    return __component_dir__
-
-
-def getattribute_wrapper(getattr_fn):
-    def __component_getattr__(instance, name):
-        component_fields = object.__getattribute__(instance, "__component_fields__")
-        if name in component_fields:
-            field = component_fields[name]
-            if isinstance(field, EmptyField):
-                raise EmptyFieldError(instance, name)
-            if isinstance(field, NonEmptyField):
-                return object.__getattribute__(instance, name)
-            if isinstance(field, InheritedField):
-                return getattr(instance.__component_parent__, name)
-        else:
-            return getattr_fn(instance, name)
-        raise AttributeError
-
-    return __component_getattr__
-
-
-def setattr_wrapper(setattr_fn):
-    def __component_setattr__(instance, name, value):
+    @functools.wraps(fn)
+    def wrapped_fn(instance, name):
         if name in instance.__component_fields__:
-            raise ValueError(
-                "Setting component field values directly is prohibited. Use Zookeeper "
-                "component configuration to set field values."
-            )
-        else:
-            return setattr_fn(instance, name, value)
+            raise ValueError("Deleting component field values is prohibited.")
+        return fn(instance, name)
 
-    return __component_setattr__
+    component_cls.__delattr__ = wrapped_fn
 
 
-def delattr_wrapper(delattr_fn):
-    def __component_delattr__(instance, name):
-        if name in instance.__component_fields__:
-            raise ValueError("Deleting component fields is prohibited.")
-        return delattr_fn(instance, name)
+def _wrap_dir(component_cls: Type) -> None:
+    fn = component_cls.__dir__  # type: ignore
 
-    return __component_delattr__
+    @functools.wraps(fn)
+    def wrapped_fn(instance) -> Set[str]:
+        return set(fn(instance)) | set(instance.__component_fields__.keys())
+
+    component_cls.__dir__ = wrapped_fn
 
 
-##################################
-# Pretty string representations. #
-##################################
+#################################
+# Pretty string representations #
+#################################
 
 
 # Indent for nesting in the string representation
 INDENT = " " * 4
 
 
-def str_key_val(key, value, color=True, single_line=False):
-    if is_component_class(value.__class__):
+def _field_key_val_str(key: str, value: Any, color: bool, single_line: bool) -> str:
+    if utils.is_component_instance(value):
         if single_line:
             value = repr(value)
         else:
             value = f"\n{INDENT}".join(str(value).split("\n"))
     elif callable(value):
         value = "<callable>"
-    elif type(value) == str:
+    elif isinstance(value, str):
         value = f'"{value}"'
-    return f"{BLUE}{key}{RESET}={YELLOW}{value}{RESET}" if color else f"{key}={value}"
+
+    return f"{key}={value}" if color else f"{key}={value}"
 
 
 def __component_repr__(instance):
-    fields = ", ".join(
-        [
-            str_key_val(
-                field_name, getattr(instance, field_name), color=False, single_line=True
-            )
-            for field_name in sorted(instance.__component_fields__)
-        ]
-    )
-    return f"{instance.__class__.__name__}({fields})"
+    field_strings = [
+        _field_key_val_str(
+            field_name, getattr(instance, field_name), color=False, single_line=True
+        )
+        for field_name in instance.__component_fields__.keys()
+    ]
+
+    joined_str = ", ".join(field_strings)
+
+    return f"{instance.__class__.__name__}({joined_str})"
 
 
 def __component_str__(instance):
-    fields = f",\n{INDENT}".join(
-        [
-            str_key_val(field_name, getattr(instance, field_name))
-            for field_name in sorted(instance.__component_fields__)
-        ]
-    )
-    return f"{instance.__class__.__name__}(\n{INDENT}{fields}\n)"
+    field_strings = [
+        _field_key_val_str(
+            field_name, getattr(instance, field_name), color=True, single_line=False
+        )
+        for field_name in instance.__component_fields__.keys()
+    ]
+
+    joined_str = f",\n{INDENT}".join(field_strings)
+
+    return f"{instance.__class__.__name__}(\n{INDENT}{joined_str}\n)"
 
 
-#######################
-# Exported functions. #
-#######################
+##########################
+# A component `__init__` #
+##########################
+
+
+def __component_init__(instance, **kwargs):
+    """
+    Accepts keyword-arguments corresponding to fields defined on the component.
+    """
+
+    # Use the `kwargs` to set field values.
+    for name, value in kwargs.items():
+        if name not in instance.__component_fields__:
+            raise TypeError(
+                "Keyword arguments passed to component `__init__` must correspond to "
+                f"component fields. Received non-matching argument '{name}'."
+            )
+
+    # Save a shallow-clone of the arguments.
+    instance.__component_instantiated_field_values__ = {**kwargs}
+
+    # This will contain configured field values that apply to this instance, if
+    # any, which override everything else.
+    instance.__component_configured_field_values__ = {}
+
+    # This will contain the names of every field of this instance and all
+    # component ancestors for which a value is defined. More names will be added
+    # during configuration.
+    instance.__component_fields_with_values_in_scope__ = set(
+        field.name
+        for field in instance.__component_fields__.values()
+        if field.has_default
+    ) | set(name for name in kwargs.keys())
+
+
+######################
+# Exported functions #
+######################
 
 
 def component(cls):
     """A decorater which turns a class into a Zookeeper component."""
 
     if not inspect.isclass(cls):
-        raise ValueError("Only classes can be decorated with @component.")
+        raise TypeError("Only classes can be decorated with @component.")
 
     if inspect.isabstract(cls):
-        raise ValueError("Abstract classes cannot be decorated with @component.")
+        raise TypeError("Abstract classes cannot be decorated with @component.")
 
-    if is_component_class(cls):
-        raise ValueError(
-            f"The class {cls} is already a component; the @component decorator cannot "
-            "be applied again."
+    if utils.is_component_class(cls):
+        raise TypeError(
+            f"The class {cls.__name__} is already a component; the @component decorator "
+            "cannot be applied again."
         )
 
-    cls.__component_name__ = convert_to_snake_case(cls.__name__)
-    cls.__component_parent__ = None
-    cls.__component_configured__ = False
-    cls.__component_fields__ = {}
+    if cls.__init__ not in (object.__init__, __component_init__):
+        # A component class could have `__component_init__` as its init method
+        # if it inherits from a component.
+        raise TypeError("Component classes must not define a custom `__init__` method.")
+    cls.__init__ = __component_init__
 
-    # Override `__getattribute__`, `__setattr__`, and `__delattr__` to correctly
-    # manage getting, setting, and deleting component fields.
-    cls.__getattribute__ = getattribute_wrapper(cls.__getattribute__)  # type: ignore
-    cls.__setattr__ = setattr_wrapper(cls.__setattr__)
-    cls.__delattr__ = delattr_wrapper(cls.__delattr__)
+    # Populate `__component_fields__` with all fields defined on this class and
+    # all superclasses. We have to go through the MRO chain and collect them in
+    # reverse order so that they are correctly overriden.
+    fields = {}
+    for base_class in reversed(inspect.getmro(cls)):
+        for name, value in base_class.__dict__.items():
+            if isinstance(value, Field):
+                fields[name] = value
+    # TODO: maybe throw/warn if no fields defined?
+    cls.__component_fields__ = fields
 
-    # Override `__dir__` so that field names are included.
-    cls.__dir__ = dir_wrapper(cls.__dir__)
-
-    # Override `__init__` to perform component initialisation and (potentially)
-    # set key-word args as field values.
-    cls.__init__ = init_wrapper(cls.__init__)
+    # Override class methods to correctly interact with component fields.
+    _wrap_getattribute(cls)
+    _wrap_setattr(cls)
+    _wrap_delattr(cls)
+    _wrap_dir(cls)
 
     # Components should have nice `__str__` and `__repr__` methods.
     cls.__str__ = __component_str__
     cls.__repr__ = __component_repr__
+
+    # These will be overriden during configuration.
+    cls.__component_name__ = cls.__name__
+    cls.__component_parent__ = None
+    cls.__component_configured__ = False
 
     return cls
 
@@ -395,46 +399,39 @@ def configure(
         instance.__component_name__ = name
 
     # Set the correct value for each field.
-    for field_name, field in instance.__component_fields__.items():
-        full_name = f"{instance.__component_name__}.{field_name}"
+    for field in instance.__component_fields__.values():
+        full_name = f"{instance.__component_name__}.{field.name}"
         field_type_name = (
-            field.annotated_type.__name__
-            if inspect.isclass(field.annotated_type)
-            else str(field.annotated_type)
+            field.type.__name__ if inspect.isclass(field.type) else str(field.type)
         )
-        component_subclasses = list(generate_component_subclasses(field.annotated_type))
+        component_subclasses = list(utils.generate_component_subclasses(field.type))
 
-        if field_name in conf:
-            field_value = conf[field_name]
+        if field.name in conf:
+            conf_field_value = conf[field.name]
             # The configuration value could be a string specifying a component
             # class to instantiate.
-            if len(component_subclasses) > 0 and isinstance(field_value, str):
+            if len(component_subclasses) > 0 and isinstance(conf_field_value, str):
                 for subclass in component_subclasses:
                     if (
-                        field_value == subclass.__name__
-                        or field_value == subclass.__qualname__
-                        or convert_to_snake_case(field_value)
-                        == convert_to_snake_case(subclass.__name__)
+                        conf_field_value == subclass.__name__
+                        or conf_field_value == subclass.__qualname__
+                        or utils.convert_to_snake_case(conf_field_value)
+                        == utils.convert_to_snake_case(subclass.__name__)
                     ):
-                        field_value = subclass()
+                        conf_field_value = subclass()
                         break
 
-            set_field_value(instance, field_name, field_value)
+            # Set the value on the instance.
+            instance.__component_configured_field_values__[
+                field.name
+            ] = conf_field_value
 
-            # If this is a 'raw' value, add a placeholder to `conf` so that it
-            # gets picked up correctly in sub-components.
-            if (
-                field_value != OVERRIDEN_CONF_VALUE
-                and field_value != NON_OVERRIDEN_CONF_VALUE
-            ):
-                conf[field_name] = OVERRIDEN_CONF_VALUE
+            # This value has now been 'consumed', so delete it from `conf`.
+            del conf[field.name]
 
-        # If there's no config value but a value is already set on the instance,
-        # we only need to add a placeholder to `conf` to make sure that the
-        # value will be accessible from sub-components. `hasattr` isn't safe so
-        # we have to check membership directly.
-        elif field_name in object.__dir__(instance):  # type: ignore
-            conf[field_name] = NON_OVERRIDEN_CONF_VALUE
+        # If there's a value in scope, we don't need to do anything.
+        elif field.name in instance.__component_fields_with_values_in_scope__:
+            pass
 
         # If there is only one concrete component subclass of the annotated
         # type, we assume the user must intend to use that subclass, and so
@@ -442,37 +439,33 @@ def configure(
         elif len(component_subclasses) == 1:
             component_cls = list(component_subclasses)[0]
             print_formatted_text(
-                f"'{type_name_str(component_cls)}' is the only concrete component "
+                f"'{utils.type_name_str(component_cls)}' is the only concrete component "
                 f"class that satisfies the type of the annotated field '{full_name}'. "
                 "Using an instance of this class by default."
             )
-            # This is safe because we don't allow `__init__` to have any
-            # positional arguments without defaults.
-            field_value = component_cls()
+            # This is safe because we don't allow custom `__init__` methods.
+            conf_field_value = component_cls()
 
-            set_field_value(instance, field_name, field_value)
-
-            # Add a placeholder to `conf` to so that this value can be accessed
-            # by sub-components.
-            conf[field_name] = NON_OVERRIDEN_CONF_VALUE
+            # Set the value on the instance.
+            instance.__component_configured_field_values__[
+                field.name
+            ] = conf_field_value
 
         # If we are running interactively, prompt for a value.
         elif interactive:
             if len(component_subclasses) > 0:
-                component_cls = prompt_for_component_subclass(
+                component_cls = utils.prompt_for_component_subclass(
                     full_name, component_subclasses
                 )
-                # This is safe because we don't allow `__init__` to have any
-                # positional arguments without defaults.
-                field_value = component_cls()
+                # This is safe because we don't allow custom `__init__` methods.
+                conf_field_value = component_cls()
             else:
-                field_value = prompt_for_value(full_name, field.annotated_type)
+                conf_field_value = utils.prompt_for_value(full_name, field.type)
 
-            set_field_value(instance, field_name, field_value)
-
-            # Add a placeholder to `conf` so that this value can be accessed by
-            # sub-components.
-            conf[field_name] = OVERRIDEN_CONF_VALUE
+            # Set the value on the instance.
+            instance.__component_configured_field_values__[
+                field.name
+            ] = conf_field_value
 
         # Otherwise, raise an appropriate error.
         else:
@@ -482,7 +475,8 @@ def configure(
                     f"has no configured value. Please configure '{full_name}' with "
                     f"one of the following component subclasses of '{field_type_name}':"
                     + "\n    ".join(
-                        [""] + list(type_name_str(c) for c in component_subclasses)
+                        [""]
+                        + list(utils.type_name_str(c) for c in component_subclasses)
                     )
                 )
             raise ValueError(
@@ -490,49 +484,46 @@ def configure(
                 f"'{full_name}' of type '{field_type_name}'."
             )
 
-    # Recursively configure any sub-components.
-    for field_name, field_type in instance.__component_fields__.items():
-        field_value = getattr(instance, field_name)
-        full_name = f"{instance.__component_name__}.{field_name}"
+        # At this point we are certain that this field has has a value, so keep
+        # track of that fact.
+        instance.__component_fields_with_values_in_scope__.add(field.name)
 
-        if (
-            is_component_class(field_value.__class__)
-            and not field_value.__component_configured__
-        ):
+    # Recursively configure any sub-components.
+    for field in instance.__component_fields__.values():
+        if not isinstance(field, ComponentField):
+            continue
+
+        sub_component_instance = getattr(instance, field.name)
+
+        full_name = f"{instance.__component_name__}.{field.name}"
+
+        if not sub_component_instance.__component_configured__:
             # Set the component parent so that inherited fields function
             # correctly.
-            field_value.__component_parent__ = instance
+            sub_component_instance.__component_parent__ = instance
+
+            # Extend the field names in scope. All fields with values defined in
+            # the scope of the parent are also accessible in the child.
+            sub_component_instance.__component_fields_with_values_in_scope__ |= (
+                instance.__component_fields_with_values_in_scope__
+            )
 
             # Configure the nested sub-component. The configuration we use
             # consists of all non-scoped keys and any keys scoped to
-            # `field_name`, where the keys scoped to `field_name` override the
+            # `field.name`, where the keys scoped to `field.name` override the
             # non-scoped keys.
             non_scoped_conf = {a: b for a, b in conf.items() if "." not in a}
             field_name_scoped_conf = {
-                a[len(f"{field_name}.") :]: b
+                a[len(f"{field.name}.") :]: b
                 for a, b in conf.items()
-                if a.startswith(f"{field_name}.")
+                if a.startswith(f"{field.name}.")
             }
             nested_conf = {**non_scoped_conf, **field_name_scoped_conf}
-            configure(field_value, nested_conf, name=full_name, interactive=interactive)
-
-    # Type check all fields.
-    for field_name, field in instance.__component_fields__.items():
-        assert field_name in instance.__component_fields__
-        field_value = getattr(instance, field_name)
-        try:
-            check_type(field_name, field_value, field.annotated_type)
-            # Because boolean `True` and `False` are coercible to ints and
-            # floats, `typeguard.check_type` doesn't throw if we e.g. pass
-            # `True` to a value expecting a float. This would, however, likely
-            # be a user error, so explicitly check for this.
-            if field.annotated_type in [float, int] and isinstance(field_value, bool):
-                raise TypeError
-        except TypeError:
-            raise TypeError(
-                f"Attempting to set field '{instance.__component_name__}.{field_name}' "
-                f"which has annotated type '{type_name_str(field.annotated_type)}' "
-                f"with value '{field_value}'."
-            ) from None
+            configure(
+                sub_component_instance,
+                nested_conf,
+                name=full_name,
+                interactive=interactive,
+            )
 
     instance.__component_configured__ = True

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -317,7 +317,7 @@ def __component_init__(instance, **kwargs):
         field.name
         for field in instance.__component_fields__.values()
         if field.has_default
-    ) | set(name for name in kwargs.keys())
+    ) | set(kwargs)
 
 
 ######################

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -334,3 +334,15 @@ def test_type_check(ExampleComponentClass):
         match="Field 'a' of component 'x' is annotated with type '<class 'int'>', which is not satisfied by default value 4.5.",
     ):
         instance.a
+
+
+def test_error_if_field_overwritten_in_subclass():
+    @component
+    class SuperClass:
+        foo: str = Field("bar")
+
+    with pytest.raises(ValueError, match="Field 'foo' is defined on super-class"):
+
+        @component
+        class SubClass(SuperClass):
+            foo = 1

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -2,18 +2,19 @@ import abc
 from typing import List
 from unittest.mock import patch
 
+import click
 import pytest
-from click import unstyle
 
 from zookeeper.core.component import component, configure
+from zookeeper.core.field import ComponentField, Field
 
 
 @pytest.fixture
 def ExampleComponentClass():
     @component
     class A:
-        a: int
-        b: str = "foo"
+        a: int = Field()
+        b: str = Field("foo")
 
     return A
 
@@ -22,9 +23,8 @@ def test_non_class_decorate_error():
     """
     An error should be raised when attempting to decorate a non-class object.
     """
-
     with pytest.raises(
-        ValueError, match="Only classes can be decorated with @component."
+        TypeError, match="Only classes can be decorated with @component."
     ):
 
         @component
@@ -36,9 +36,8 @@ def test_abstract_class_decorate_error():
     """
     An error should be raised when attempting to decorate an abstract class.
     """
-
     with pytest.raises(
-        ValueError, match="Abstract classes cannot be decorated with @component."
+        TypeError, match="Abstract classes cannot be decorated with @component."
     ):
 
         @component
@@ -48,15 +47,14 @@ def test_abstract_class_decorate_error():
                 pass
 
 
-def test_positional_args_init_decorate_error():
+def test_init_decorate_error():
     """
     An error should be raised when attempting to decorate a class with an
-    `__init__` methods that takes positional arguments.
+    `__init__` method.
     """
-
     with pytest.raises(
-        ValueError,
-        match=r"^The `__init__` method of a component must not accept any positional arguments",
+        TypeError,
+        match="Component classes must not define a custom `__init__` method.",
     ):
 
         @component
@@ -64,20 +62,6 @@ def test_positional_args_init_decorate_error():
             def __init__(self, a, b=5):
                 self.a = a
                 self.b = b
-
-
-def test_existing_init():
-    """
-    If the decorated class has an `__init__` method, that method should be
-    called on instantiation.
-    """
-
-    @component
-    class A:
-        def __init__(self, foo="bar"):
-            self.foo = foo
-
-    assert A().foo == "bar"
 
 
 def test_no_init(ExampleComponentClass):
@@ -95,15 +79,19 @@ def test_no_init(ExampleComponentClass):
     assert x.a == 0
     assert x.b == "bar"
 
+    # Verify that arguments are disallowed (the 1 positional argument the error
+    # message refers to is `self`).
     with pytest.raises(
-        TypeError,
-        match=r"__component_init__\(\) takes 1 positional argument but 2 were given",
+        TypeError, match=r"takes 1 positional argument but 2 were given",
     ):
         ExampleComponentClass("foobar")
 
     with pytest.raises(
-        ValueError,
-        match=r"^Argument 'some_other_field_name' does not correspond to any annotated field of",
+        TypeError,
+        match=(
+            "Keyword arguments passed to component `__init__` must correspond to "
+            "component fields. Received non-matching argument 'some_other_field_name'"
+        ),
     ):
         ExampleComponentClass(some_other_field_name=0)
 
@@ -122,20 +110,20 @@ def test_configure_scoped_override_field_values():
 
     @component
     class Child:
-        a: int
-        b: str
-        c: List[float]
+        a: int = Field()
+        b: str = Field()
+        c: List[float] = Field()
 
     @component
     class Parent:
-        b: str = "bar"
-        child: Child = Child()
+        b: str = Field("bar")
+        child: Child = ComponentField(Child)
 
     @component
     class GrandParent:
-        a: int
-        b: str
-        parent: Parent = Parent()
+        a: int = Field()
+        b: str = Field()
+        parent: Parent = ComponentField(Parent)
 
     grand_parent = GrandParent()
 
@@ -189,7 +177,7 @@ def test_configure_automatically_instantiate_subcomponent():
 
     @component
     class Parent:
-        child: AbstractChild
+        child: AbstractChild = ComponentField()
 
     # There is only a single defined component subclass of `AbstractChild`,
     # `Child1`, so we should be able to configure an instance of `Parent` and
@@ -209,7 +197,7 @@ def test_configure_automatically_instantiate_subcomponent():
     p = Parent()
     with pytest.raises(
         ValueError,
-        match="Annotated field 'parent.child' of type 'AbstractChild' has no configured value. Please configure 'parent.child' with one of the following component subclasses",
+        match=r"^Annotated field 'Parent.child' of type 'AbstractChild' has no configured value. Please configure 'Parent.child' with one of the following component subclasses",
     ):
         configure(p, {})
 
@@ -275,7 +263,7 @@ def test_configure_interactive_prompt_for_subcomponent_choice():
 
     @component
     class Parent:
-        child: AbstractChild
+        child: AbstractChild = ComponentField()
 
     # The prompt lists the concrete component subclasses (alphabetically) and
     # asks for an an integer input corresponding to an index in this list.
@@ -303,25 +291,25 @@ def test_str_and_repr():
 
     @component
     class Child:
-        a: int
-        b: str
-        c: List[float]
+        a: int = Field()
+        b: str = Field()
+        c: List[float] = Field()
 
     @component
     class Parent:
-        b: str = "bar"
-        child: Child = Child()
+        b: str = Field("bar")
+        child: Child = ComponentField(Child)
 
     p = Parent()
 
     configure(p, {"a": 10, "b": "foo", "c": [1.5, -1.2]}, name="parent")
 
     assert (
-        unstyle(repr(p))
+        click.unstyle(repr(p))
         == """Parent(b="foo", child=Child(a=10, b="foo", c=[1.5, -1.2]))"""
     )
     assert (
-        unstyle(str(p))
+        click.unstyle(str(p))
         == """Parent(
     b="foo",
     child=Child(
@@ -336,16 +324,13 @@ def test_str_and_repr():
 def test_type_check(ExampleComponentClass):
     """During configuration we should type-check all field values."""
 
-    # Attempting to set an int field with a float.
-    with pytest.raises(
-        TypeError,
-        match=r"^Attempting to set field 'x.a' which has annotated type 'int' with value '4.5'.$",
-    ):
-        configure(ExampleComponentClass(), {"a": 4.5}, name="x")
+    instance = ExampleComponentClass()
 
-    # Attempting to set a str field with a bool.
+    configure(instance, {"a": 4.5}, name="x")
+
+    # Attempting to access the field should now raise a type error.
     with pytest.raises(
         TypeError,
-        match=r"^Attempting to set field 'x.b' which has annotated type 'str' with value 'True'.$",
+        match="Field 'a' of component 'x' is annotated with type '<class 'int'>', which is not satisfied by default value 4.5.",
     ):
-        configure(ExampleComponentClass(), {"a": 3, "b": True}, name="x")
+        instance.a

--- a/zookeeper/core/field.py
+++ b/zookeeper/core/field.py
@@ -53,7 +53,7 @@ class Field(Generic[_ComponentType, _FieldType]):
 
         if default_value is _missing:
             default_factory = None
-        elif isinstance(default_value, (int, float, bool, str, type(None))):
+        elif default_value is None or isinstance(default_value, (int, float, bool, str)):
             default_factory = lambda instance: default_value  # noqa: E731
         elif inspect.isfunction(default_value):
             signature = inspect.signature(default_value)

--- a/zookeeper/core/field.py
+++ b/zookeeper/core/field.py
@@ -1,0 +1,230 @@
+import inspect
+from typing import Callable, Generic, Type, TypeVar, Union
+
+from zookeeper.core import utils
+from zookeeper.core.partial_component import PartialComponent
+
+
+# A sentinel class/object for missing default values.
+class _MISSING:
+    def __repr__(self):
+        return f"<missing>"
+
+
+_missing = _MISSING()
+
+
+# Type-variables to parameterise fields.
+_ComponentType = TypeVar("_ComponentType")
+_FieldType = TypeVar("_FieldType")
+
+
+class Field(Generic[_ComponentType, _FieldType]):
+    """
+    A configurable field for Zookeeper components. Fields must be typed, may
+    take default values, and are configurable through the CLI.
+
+    This class is not appropriate for nesting child sub-components; for this,
+    use `ComponentField` instead.
+
+    Internally, it is expected that each component will cache the result of
+    `get_default`.
+    """
+
+    def __init__(
+        self,
+        default_value: Union[
+            _MISSING,
+            _FieldType,
+            Callable[[], _FieldType],
+            Callable[[_ComponentType], _FieldType],
+        ] = _missing,
+    ):
+        # Define here once to avoid having to define twice below.
+        default_value_error = TypeError(
+            "If `default_value` is passed to `Field`, it must be either:\n"
+            "- An immutable value (int, float, bool, string, or None).\n"
+            "- A function or lambda accepting no arguments or a single\n"
+            "  argument (`self`), and returning the default value.\n"
+            f"Received: {default_value}."
+        )
+
+        return_annotation = inspect.Signature.empty
+
+        if default_value is _missing:
+            default_factory = None
+        elif isinstance(default_value, (int, float, bool, str, type(None))):
+            default_factory = lambda instance: default_value  # noqa: E731
+        elif inspect.isfunction(default_value):
+            signature = inspect.signature(default_value)
+            return_annotation = signature.return_annotation
+            if len(signature.parameters) == 0:
+                default_factory = lambda instance: default_value()  # noqa: E731
+            elif len(signature.parameters) == 1 and all(
+                signature.parameters[name].kind
+                not in (
+                    inspect.Parameter.VAR_POSITIONAL,
+                    inspect.Parameter.VAR_KEYWORD,
+                )
+                for name in signature.parameters
+            ):
+                default_factory = default_value
+            else:
+                raise default_value_error
+        else:
+            raise default_value_error
+
+        self._registered = False
+        self._return_annotation = return_annotation
+        self._default_factory = default_factory
+
+    # This follows the PEP 487 `__set_name__` protocol; this name is called
+    # automatically on every object defined within a class body, passing in the
+    # class object and name of the descriptor. We use it here to obtain the name
+    # and type of the field.
+    def __set_name__(self, host_component_class: Type[_ComponentType], name: str):
+        if self._registered:
+            raise ValueError("This field has already been registered to a component.")
+        if name.startswith("_"):
+            raise ValueError("Field names cannot start with underscores.")
+        try:
+            type_annotation = host_component_class.__annotations__[name]
+            if (
+                self._return_annotation is not inspect.Signature.empty
+                and type_annotation != self._return_annotation
+            ):
+                raise TypeError(
+                    f"Two non-equal type annotations found for field '{name}': "
+                    f"{type_annotation} and {self._return_annotation}."
+                )
+        except (AttributeError, KeyError):
+            if self._return_annotation is inspect.Signature.empty:
+                raise TypeError(
+                    "Fields must be defined inside the component class definition, "
+                    "with a type-annotation in one of the following ways:\n\n"
+                    "```\n"
+                    "@component\n"
+                    "class ComponentClass:\n"
+                    "    ...\n"
+                    "    # Like this\n"
+                    "    name_1: type_1 = Field(default_value_1)\n"
+                    "    ...\n"
+                    "    # Or like this\n"
+                    "    @Field\n"
+                    "    def name_2(self) -> type_2:\n"
+                    "        ...\n"
+                    "        return default_value_2\n"
+                    "```\n\n"
+                    f"Unable to find a type annotation for field '{name}' on class "
+                    f"'{host_component_class.__name__}'."
+                )
+            type_annotation = self._return_annotation
+
+        self.name = name
+        self.host_component_class = host_component_class
+        self.type = type_annotation
+        self._registered = True
+
+    @property
+    def has_default(self) -> bool:
+        if not self._registered:
+            raise ValueError("This field has not been registered to a component.")
+        return self._default_factory is not None
+
+    def get_default(self, component_instance: _ComponentType) -> _FieldType:
+        if not self._registered:
+            raise ValueError("This field has not been registered to a component.")
+        if not self.has_default:
+            raise AttributeError(
+                f"Field '{self.name}' has no default or configured value."
+            )
+        if not isinstance(component_instance, self.host_component_class):
+            raise TypeError(
+                f"Field '{self.name}' belongs to component "
+                f"'{self.host_component_class.__name__}'; `get_default` must be called "
+                f"with an instance of '{self.host_component_class.__name__}'. Received: "
+                f"{repr(component_instance)}."
+            )
+
+        return self._default_factory(component_instance)
+
+
+# TODO: Maybe add lower-case alias `field`?
+
+
+class ComponentField(Field, Generic[_ComponentType, _FieldType]):
+    def __init__(
+        self,
+        default_component_class: Union[
+            _MISSING, _FieldType, PartialComponent[_FieldType]
+        ] = _missing,
+    ):
+        if default_component_class is _missing:
+            default_factory = None
+        elif isinstance(
+            default_component_class, PartialComponent
+        ) or utils.is_component_class(default_component_class):
+            default_factory = default_component_class
+        elif utils.is_component_instance:
+            raise TypeError(
+                "The `default_component_class` passed to `ComponentField` must be "
+                "a component class, not a component instance. Received: "
+                f"{repr(default_component_class)}."
+            )
+        else:
+            raise TypeError(
+                "The `default_component_class` passed to `ComponentField` must be "
+                "either a component class or a `PartialComponent`."
+            )
+
+        self._registered = False
+        self._default_factory = default_factory
+
+    def __set_name__(self, host_component_class: Type[_ComponentType], name: str):
+        if self._registered:
+            raise ValueError("This field has already been registered to a component.")
+        if name.startswith("_"):
+            raise ValueError("Field names cannot start with underscores.")
+        try:
+            type_annotation = host_component_class.__annotations__[name]
+        except (AttributeError, KeyError):
+            raise TypeError(
+                "ComponentFields must be defined inside the component class definition, "
+                "with a type-annotation as follows:\n\n"
+                "```\n"
+                "@component\n"
+                "class ParentComponentClass:\n"
+                "    field_name: SomeChildComponentType = ComponentField(\n"
+                "        SomeDefaultChildComponentClass\n"
+                "    )\n"
+                "```\n"
+                "\nUnlike `Field`, `ComponentField` cannot be used as a decorator.\n\n"
+                f"Unable to find a type annotation for field '{name}' on class "
+                f"'{host_component_class.__name__}'."
+            )
+
+        self.name = name
+        self.host_component_class = host_component_class
+        self.type = type_annotation
+        self._registered = True
+
+    def get_default(self, component_instance: _ComponentType) -> _FieldType:
+        if not self._registered:
+            raise ValueError("This field has not been registered to a component.")
+        if not self.has_default:
+            raise AttributeError(
+                f"ComponentField '{self.name}' has no default or configured component "
+                "class."
+            )
+        if not isinstance(component_instance, self.host_component_class):
+            raise TypeError(
+                f"ComponentField '{self.name}' belongs to component "
+                f"'{self.host_component_class.__name__}'; `get_default` must be called "
+                f"with an instance of '{self.host_component_class.__name__}'. Received: "
+                f"{repr(component_instance)}."
+            )
+
+        # We build the instance without passing in any additional arguments. The
+        # child instance will be able to pick up any missing field values from
+        # the parent in the usual way, as it will be a nested sub-component.
+        return self._default_factory()

--- a/zookeeper/core/field.py
+++ b/zookeeper/core/field.py
@@ -78,7 +78,7 @@ class Field(Generic[_ComponentType, _FieldType]):
         self._return_annotation = return_annotation
         self._default_factory = default_factory
 
-    # This follows the PEP 487 `__set_name__` protocol; this name is called
+    # This follows the PEP 487 `__set_name__` protocol; this method is called
     # automatically on every object defined within a class body, passing in the
     # class object and name of the descriptor. We use it here to obtain the name
     # and type of the field.

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -1,0 +1,173 @@
+from typing import List, Optional
+
+import pytest
+
+from zookeeper.core.component import component
+from zookeeper.core.field import ComponentField, Field
+from zookeeper.core.partial_component import PartialComponent
+
+
+def test_init_non_immutable_non_callable():
+    with pytest.raises(
+        TypeError, match="If `default_value` is passed to `Field`, it must be either:"
+    ):
+        Field([1, 2, 3])
+
+
+def test_init_callable_many_arg():
+    with pytest.raises(
+        TypeError, match="If `default_value` is passed to `Field`, it must be either:"
+    ):
+        Field(lambda x, y, z: x + y + z)
+
+
+def test_no_default():
+    class A:
+        foo: int = Field()
+
+    assert not A.foo.has_default  # type: ignore
+
+    with pytest.raises(
+        AttributeError, match="Field 'foo' has no default or configured value"
+    ):
+        A.foo.get_default(A())  # type: ignore
+
+
+def test_immutable_default():
+    class A:
+        foo: int = Field(5)
+        bar: float = Field(1.2)
+        baz: bool = Field(False)
+        foobar: Optional[int] = Field(None)
+
+    for field_name, expected_default in zip(
+        ["foo", "bar", "baz", "foobar"], [5, 1.2, False, None]
+    ):
+        instance = A()
+        field = getattr(A, field_name)
+        assert field.has_default
+        assert field.get_default(instance) == expected_default
+
+
+def test_non_immutable_non_factory_default():
+    with pytest.raises(TypeError):
+        Field([1, 2, 3])
+
+
+def test_factory_default():
+    class A:
+        foo: int = Field(lambda: 7)
+        bar: List[int] = Field(lambda instance: [instance.baz])
+        baz = 2
+
+    instance = A()
+
+    assert A.foo.has_default  # type: ignore
+    assert A.foo.get_default(instance) == 7  # type: ignore
+
+    assert A.bar.has_default  # type: ignore
+    bar_default = A.bar.get_default(instance)  # type: ignore
+    assert isinstance(bar_default, list)
+    assert bar_default[0] == 2
+
+
+def test_decorated_field():
+    class A:
+        @Field
+        def foo() -> float:
+            return 3.14
+
+        # Class `A` would usually be decorated with @component, which would
+        # modify `__getattribute__` so that calling `self.foo` correctly fetches
+        # the default value of the field. However, as we want to test `Field`
+        # independently of `component`, use this workaround here (otherwise the
+        # `bar` definition below would fail).
+        @property
+        def foo_value(self):
+            return A.foo.get_default(self)
+
+        @Field
+        def bar(self) -> int:
+            return int(self.foo_value ** self.foo_value)
+
+    instance = A()
+
+    assert A.foo.has_default  # type: ignore
+    assert A.foo.get_default(instance) == 3.14
+
+    assert A.bar.has_default  # type: ignore
+    assert A.bar.get_default(instance) == 36
+
+
+def test_unregistered_field():
+    field = Field(5)
+
+    with pytest.raises(
+        ValueError, match="This field has not been registered to a component"
+    ):
+        field.has_default
+
+    with pytest.raises(
+        ValueError, match="This field has not been registered to a component"
+    ):
+        field.get_default(object())
+
+
+def test_prohibit_underscore_field_name():
+    # This is ugly because the actual exception raised is a `ValueError` with
+    # appropriate error message, but the the standard library catches that
+    # exception and chains it with a RuntimeError. There's no (easy) way to get
+    # the original exception and error message.
+    with pytest.raises(RuntimeError):
+
+        class A:
+            _field = Field()
+
+
+# Used in the `ComponentField` tests below.
+class AbstractClass:
+    a: int = Field()
+
+
+@component
+class ConcreteComponent:
+    a: int = Field(2)
+
+
+def test_component_field_component_instance_default():
+    with pytest.raises(
+        TypeError,
+        match="The `default_component_class` passed to `ComponentField` must be a component class, not a component instance.",
+    ):
+        ComponentField(ConcreteComponent())
+
+
+def test_component_field_no_default():
+    class A:
+        foo: AbstractClass = ComponentField()
+
+    assert not A.foo.has_default  # type: ignore
+
+    with pytest.raises(
+        AttributeError,
+        match="ComponentField 'foo' has no default or configured component class.",
+    ):
+        A.foo.get_default(A())  # type: ignore
+
+
+def test_component_field_component_class_default():
+    class A:
+        foo: AbstractClass = ComponentField(ConcreteComponent)
+
+    assert A.foo.has_default  # type: ignore
+    assert isinstance(A.foo.get_default(A()), ConcreteComponent)  # type: ignore
+
+
+def test_component_field_partial_component_default():
+    class A:
+        foo: AbstractClass = ComponentField(PartialComponent(ConcreteComponent, a=5))
+
+    assert A.foo.has_default  # type: ignore
+    default_value = A.foo.get_default(A())  # type: ignore
+    assert isinstance(default_value, ConcreteComponent)
+    assert default_value.a == 5

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -9,14 +9,14 @@ from zookeeper.core.partial_component import PartialComponent
 
 def test_init_non_immutable_non_callable():
     with pytest.raises(
-        TypeError, match="If `default_value` is passed to `Field`, it must be either:"
+        TypeError, match="If `default` is passed to `Field`, it must be either:"
     ):
         Field([1, 2, 3])
 
 
 def test_init_callable_many_arg():
     with pytest.raises(
-        TypeError, match="If `default_value` is passed to `Field`, it must be either:"
+        TypeError, match="If `default` is passed to `Field`, it must be either:"
     ):
         Field(lambda x, y, z: x + y + z)
 
@@ -137,7 +137,7 @@ class ConcreteComponent:
 def test_component_field_component_instance_default():
     with pytest.raises(
         TypeError,
-        match="The `default_component_class` passed to `ComponentField` must be a component class, not a component instance.",
+        match="The `default` passed to `ComponentField` must be a component class, not a component instance.",
     ):
         ComponentField(ConcreteComponent())
 

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -171,3 +171,16 @@ def test_component_field_partial_component_default():
     default_value = A.foo.get_default(A())  # type: ignore
     assert isinstance(default_value, ConcreteComponent)
     assert default_value.a == 5
+
+
+def test_component_field_kwargs():
+    with pytest.raises(TypeError, match="Keyword arguments can only be passed"):
+        ComponentField(a=1, b=2, c=3)
+
+    class A:
+        foo: AbstractClass = ComponentField(ConcreteComponent, a=5)
+
+    assert A.foo.has_default  # type: ignore
+    default_value = A.foo.get_default(A())  # type: ignore
+    assert isinstance(default_value, ConcreteComponent)
+    assert default_value.a == 5

--- a/zookeeper/core/partial_component.py
+++ b/zookeeper/core/partial_component.py
@@ -1,0 +1,112 @@
+import inspect
+from typing import Generic, Type, TypeVar
+
+from zookeeper.core import utils
+
+# A type-variable used to parameterise `PartialComponent`. This is for static
+# type-checking.
+_ComponentType = TypeVar("_ComponentType")
+
+
+# Defined once here to avoid having to define it twice in the `__init__` body.
+_kwargs_error = TypeError(
+    "Keyword arguments passed to `PartialComponent` must be either:\n"
+    "- An immutable value (int, float, bool, string, or None).\n"
+    "- A function or lambda accepting no arguments and returning the \n"
+    "  value that should be passed to the component upon instantiation.\n"
+    "- Another `PartialComponent`."
+    "Wrapping non-immutable values in a function / lambda allows the values "
+    "to be lazily evaluated; they won't be created at all if the partial "
+    "component is never instantiated."
+)
+
+
+class PartialComponent(Generic[_ComponentType]):
+    """
+    A wrapper around a component class that represents the component with some
+    default field values modified, similar in principle to `functools.partial`.
+
+    `PartialComponent(SomeComponentClass, a=3)(b=4)` is equivalent to
+    `SomeComponentClass(a=3, b=4)`.
+    """
+
+    def __init__(self, component_class: Type[_ComponentType], **kwargs):
+        if utils.is_component_instance(component_class):
+            raise TypeError(
+                "`PartialComponent` must be passed component classes, not component "
+                f"instances. Received: {repr(component_class)}"
+            )
+        if not utils.is_component_class(component_class):
+            raise TypeError(
+                "The class passed to `PartialComponent` must be a component class. "
+                f"Received: {component_class}."
+            )
+        if len(kwargs) == 0:
+            raise TypeError(
+                "`PartialComponent` must receive at least one keyword argument."
+            )
+
+        lazy_kwargs = {}
+        for name, value in kwargs.items():
+            if name not in component_class.__component_fields__:
+                raise TypeError(
+                    f"Keyword argument '{name}' passed to `PartialComponent` does "
+                    "not correspond to any field of component class "
+                    f"'{component_class.__name__}'."
+                )
+            if isinstance(value, (int, float, bool, str, type(None), PartialComponent)):
+                lazy_kwargs[name] = lambda: value
+            else:
+                if not inspect.isfunction(value):
+                    raise _kwargs_error
+                if len(inspect.signature(value).parameters) == 0:
+                    lazy_kwargs[name] = value
+                else:
+                    raise _kwargs_error
+
+        self._component_class = component_class
+        self._lazy_kwargs = lazy_kwargs
+
+    # This follows the PEP 487 `__set_name__` protocol; this method is called
+    # automatically on every object defined within a class body. We use it here
+    # to disallow setting instances directly on classes.
+    def __set_name__(self, cls, name):
+        raise ValueError(
+            "`PartialComponent` instances should not be directly assigned to class "
+            "bodies. You should instead use `PartialComponent` inside a "
+            "`ComponentField`, like so:\n"
+            "```\n"
+            "@component\n"
+            "class ParentComponentClass:\n"
+            "    child_component: SomeChildComponentType = ComponentField(\n"
+            "        PartialComponent(\n"
+            "            SomeDefaultChildComponentClass,\n"
+            "            some_arg=some_default_value,\n"
+            "            some_other_arg=some_other_default_value,\n"
+            "            ...\n"
+            "        )\n"
+            "    )\n"
+            "```"
+        )
+
+    def __call__(self, **kwargs) -> _ComponentType:
+        for name, value in kwargs.items():
+            if name not in self._component_class.__component_fields__:
+                raise TypeError(
+                    f"Keyword argument '{name}' passed to `PartialComponent` does "
+                    "not correspond to any field of component class "
+                    f"'{self._component_class.__name__}'."
+                )
+
+        # TODO: perhaps consider passing the argument-factories rather than
+        #       evaluating the values here, as it's still possible that these
+        #       values won't end up being used.
+        evaluted_saved_kwargs = {
+            name: value()
+            for name, value in self._lazy_kwargs.items()
+            if name not in kwargs
+        }
+
+        combined_kwargs = {**evaluted_saved_kwargs, **kwargs}
+
+        return self._component_class(**combined_kwargs)

--- a/zookeeper/core/partial_component.py
+++ b/zookeeper/core/partial_component.py
@@ -54,8 +54,8 @@ class PartialComponent(Generic[_ComponentType]):
                     "not correspond to any field of component class "
                     f"'{component_class.__name__}'."
                 )
-            if isinstance(value, (int, float, bool, str, type(None), PartialComponent)):
-                lazy_kwargs[name] = lambda: value
+            if utils.is_immutable(value):
+                lazy_kwargs[name] = utils.wrap_in_callable(value)
             else:
                 if not inspect.isfunction(value):
                     raise _kwargs_error

--- a/zookeeper/core/partial_component_test.py
+++ b/zookeeper/core/partial_component_test.py
@@ -1,0 +1,69 @@
+import pytest
+
+from zookeeper.core.component import component
+from zookeeper.core.field import ComponentField, Field
+from zookeeper.core.partial_component import PartialComponent
+
+
+@pytest.fixture
+def ExampleComponentClasses():
+    class AbstractChild:
+        pass
+
+    @component
+    class Child1(AbstractChild):
+        a: int = Field()
+        b: str = Field("foo")
+
+    @component
+    class Child2(AbstractChild):
+        c: float = Field(3.14)
+
+    @component
+    class Parent:
+        child: AbstractChild = ComponentField()
+
+    return Parent, Child1, Child2
+
+
+def test_init_error_on_non_component():
+    with pytest.raises(
+        TypeError,
+        match="The class passed to `PartialComponent` must be a component class.",
+    ):
+        PartialComponent(2.71, a=3)  # type: ignore
+
+    with pytest.raises(
+        TypeError,
+        match="The class passed to `PartialComponent` must be a component class.",
+    ):
+        PartialComponent(lambda x: x * 2, a=3)  # type: ignore
+
+    class Test:
+        a: int
+
+    with pytest.raises(
+        TypeError,
+        match="The class passed to `PartialComponent` must be a component class.",
+    ):
+        PartialComponent(Test, a=3)
+
+    @component
+    class Test2:
+        a: int = Field(5)
+
+    with pytest.raises(
+        TypeError,
+        match="`PartialComponent` must be passed component classes, not component instances.",
+    ):
+        PartialComponent(Test2(), a=3)  # type: ignore
+
+
+def test_init_error_no_kwargs(ExampleComponentClasses):
+    _, _, Child2 = ExampleComponentClasses
+
+    with pytest.raises(
+        TypeError,
+        match="`PartialComponent` must receive at least one keyword argument.",
+    ):
+        PartialComponent(Child2)

--- a/zookeeper/core/task.py
+++ b/zookeeper/core/task.py
@@ -21,16 +21,16 @@ def task(cls):
     cls = component(cls)
 
     if not (hasattr(cls, "run") and callable(cls.run)):
-        raise ValueError("Classes decorated with @task must define a `run` method.")
+        raise TypeError("Classes decorated with @task must define a `run` method.")
 
     # Enforce argument-less `run`
 
     call_args = inspect.signature(cls.run).parameters
     if len(call_args) > 1 or len(call_args) == 1 and "self" not in call_args:
-        raise ValueError(
-            "A task class must define a `run` method taking no arguments except "
+        raise TypeError(
+            "A @task class must define a `run` method taking no arguments except "
             f"`self`, which runs the task, but `{cls.__name__}.run` accepts arguments "
-            f"{call_args}."
+            f"{tuple(name for name in call_args)}."
         )
 
     # Register a CLI command to run the task.

--- a/zookeeper/core/task_test.py
+++ b/zookeeper/core/task_test.py
@@ -28,7 +28,7 @@ def test_no_run_error():
     """Tasks without `run` should cause an error."""
 
     with pytest.raises(
-        ValueError, match="Classes decorated with @task must define a `run` method."
+        TypeError, match="Classes decorated with @task must define a `run` method."
     ):
 
         @task
@@ -42,4 +42,12 @@ def test_run_with_args_error():
     a ValueError.
     """
 
-    pass
+    with pytest.raises(
+        TypeError,
+        match=r"^A @task class must define a `run` method taking no arguments except `self`",
+    ):
+
+        @task
+        class T:
+            def run(a, b):
+                pass

--- a/zookeeper/core/utils.py
+++ b/zookeeper/core/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 from ast import literal_eval
-from typing import Any, Iterator, Sequence, Type
+from typing import Any, Callable, Iterator, Sequence, Type, TypeVar
 
 from prompt_toolkit import print_formatted_text, prompt
 
@@ -50,6 +50,34 @@ def generate_component_ancestors_with_field(
         if field_name in parent.__component_fields__:
             yield parent
         parent = parent.__component_parent__
+
+
+T = TypeVar("T")
+
+
+def wrap_in_callable(value: T) -> Callable[[], T]:
+    def wrapper():
+        return value
+
+    return wrapper
+
+
+def is_immutable(value: Any) -> bool:
+    """
+    Decide the immutability of `value`. Recurses a single level if `value` is a
+    set or a tuple, but does not recurse infinitely.
+    """
+    return (
+        value is None
+        or isinstance(value, (int, float, bool, str, frozenset))
+        or (
+            isinstance(value, (set, tuple))
+            and all(
+                isinstance(inner_value, (int, float, bool, str, frozenset))
+                for inner_value in value
+            )
+        )
+    )
 
 
 def type_name_str(type) -> str:

--- a/zookeeper/tf/experiment.py
+++ b/zookeeper/tf/experiment.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 from tensorflow import keras
 
+from zookeeper.core.field import ComponentField, Field
 from zookeeper.tf.dataset import Dataset
 from zookeeper.tf.model import Model
 from zookeeper.tf.preprocessing import Preprocessing
@@ -14,12 +15,12 @@ class Experiment:
     """
 
     # Nested components
-    dataset: Dataset
-    preprocessing: Preprocessing
-    model: Model
+    dataset: Dataset = ComponentField()
+    preprocessing: Preprocessing = ComponentField()
+    model: Model = ComponentField()
 
     # Parameters
-    epochs: int
-    batch_size: int
-    loss: Optional[Union[keras.losses.Loss, str]]
-    optimizer: Union[keras.optimizers.Optimizer, str]
+    epochs: int = Field()
+    batch_size: int = Field()
+    loss: Optional[Union[keras.losses.Loss, str]] = Field()
+    optimizer: Union[keras.optimizers.Optimizer, str] = Field()

--- a/zookeeper/tf/preprocessing.py
+++ b/zookeeper/tf/preprocessing.py
@@ -5,6 +5,8 @@ from typing import Dict, Optional, Tuple, Union
 import tensorflow as tf
 import tensorflow_datasets as tfds
 
+from zookeeper.core.field import Field
+
 
 def pass_training_kwarg(function, training=False):
     if "training" in inspect.signature(function).parameters:
@@ -15,10 +17,10 @@ def pass_training_kwarg(function, training=False):
 class Preprocessing:
     """A wrapper around `tf.data` preprocessing."""
 
-    decoders: Optional[Dict[str, Union[tfds.decode.Decoder, Dict]]] = None
+    decoders: Optional[Dict[str, Union[tfds.decode.Decoder, Dict]]] = Field(None)
 
     # The shape of the processed input. Must match the output of `input()`.
-    input_shape: Tuple[int, int, int]
+    input_shape: Tuple[int, int, int] = Field()
 
     def input(self, data, training) -> tf.Tensor:
         """


### PR DESCRIPTION
Components no longer automatically pick-up all type-annotated descriptors as fields. Instead, the user now has to explicitly define a `Field()` (for non-sub-component fields) or a `ComponentField()` (for sub-component fields). This API change slightly increases verbosity but should reduce user confusion.

Also introduces a `PartialComponent` class.