### PR TITLE
Allow `ComponentField`s to be optional.

### DIFF
--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List
+from typing import List, Optional
 from unittest.mock import patch
 
 import click
@@ -346,3 +346,13 @@ def test_error_if_field_overwritten_in_subclass():
         @component
         class SubClass(SuperClass):
             foo = 1
+
+
+def test_component_field_optional_type_check():
+    class A:
+        pass
+
+    # This should not raise an error:
+    @component
+    class B:
+        foo: Optional[A] = ComponentField(None)

--- a/zookeeper/core/field.py
+++ b/zookeeper/core/field.py
@@ -173,7 +173,7 @@ class ComponentField(Field, Generic[C, F]):
     def __init__(
         self, default: Union[Missing, F, PartialComponent[F]] = missing, **kwargs,
     ):
-        if default is missing:
+        if default in (missing, None):
             if len(kwargs) > 0:
                 raise TypeError(
                     "Keyword arguments can only be passed to `ComponentField` if "
@@ -238,6 +238,8 @@ class ComponentField(Field, Generic[C, F]):
                 f"ComponentField '{self.name}' has no default or configured component "
                 "class."
             )
+        if self._default is None:
+            return self._default
         if not isinstance(component_instance, self.host_component_class):
             raise TypeError(
                 f"ComponentField '{self.name}' belongs to component "

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -184,3 +184,12 @@ def test_component_field_kwargs():
     default_value = A.foo.get_default(A())  # type: ignore
     assert isinstance(default_value, ConcreteComponent)
     assert default_value.a == 5
+
+
+def test_component_field_optional():
+    # This should not raise an exception...
+    ComponentField(None)
+
+    # ...but this should
+    with pytest.raises(TypeError):
+        ComponentField(None, a=1, b=2, c=3)


### PR DESCRIPTION
This allows a component to effectively be optional, by letting `None` be passed into a `ComponentField`.

This feature is necessary for Larq Zoo.