### PR TITLE
Add `allow_missing` as a flag to `Field`s and `ComponentField`s.

### DIFF
--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -511,6 +511,11 @@ def configure(
         elif field.name in instance.__component_fields_with_values_in_scope__:
             pass
 
+        # If the field explicitly allows values to be missing, there's no need
+        # to do anything.
+        elif field.allow_missing:
+            pass
+
         # If there is only one concrete component subclass of the annotated
         # type, we assume the user must intend to use that subclass, and so
         # instantiate and use an instance automatically.
@@ -627,7 +632,12 @@ def configure(
         if not isinstance(field, ComponentField):
             continue
 
-        sub_component_instance = base_getattr(instance, field.name)
+        try:
+            sub_component_instance = base_getattr(instance, field.name)
+        except AttributeError as e:
+            if field.allow_missing:
+                continue
+            raise e from None
 
         full_name = f"{instance.__component_name__}.{field.name}"
 

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 from unittest.mock import patch
 
 import click
@@ -339,18 +339,6 @@ def test_error_if_field_overwritten_in_subclass():
         @component
         class SubClass(SuperClass):
             foo = 1
-
-
-def test_component_field_optional_type_check():
-    class A:
-        pass
-
-    @component
-    class B:
-        foo: Optional[A] = ComponentField(None)
-
-    # This should not raise an error.
-    B.foo
 
 
 def test_component_field_factory_type_check(capsys):

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -467,3 +467,61 @@ def test_component_configure_error_non_existant_key():
         match="Key 'non_existent_field' does not correspond to any field of component 'GrandParent.parent'.",
     ):
         configure(GrandParent(), {"parent.non_existent_field": "bar"})
+
+
+def test_component_configure_field_allow_missing():
+    @component
+    class A:
+        a: int = Field()
+        b: float = Field(allow_missing=True)
+
+        @Field
+        def c(self) -> float:
+            if hasattr(self, "b"):
+                return self.b
+            return self.a
+
+    # Missing field 'a' should cause an error.
+    with pytest.raises(
+        ValueError,
+        match="No configuration value found for annotated field 'A.a' of type 'int'.",
+    ):
+        configure(A(), {"b": 3.14})
+
+    # But missing field 'b' should not cause an error.
+    instance = A()
+    configure(instance, {"a": 0})
+    assert instance.c == 0
+    instance = A()
+    configure(instance, {"a": 0, "b": 3.14})
+    assert instance.c == 3.14
+
+
+def test_component_configure_component_field_allow_missing():
+    class Base:
+        a: int = Field()
+
+    @component
+    class Child1(Base):
+        a = Field(5)
+
+    @component
+    class Child2(Base):
+        a = Field(5)
+
+    @component
+    class Parent:
+        child: Base = ComponentField()
+        child_allow_missing: Base = ComponentField(allow_missing=True)
+
+    # Missing out "child" should cause an error.
+    with pytest.raises(
+        ValueError,
+        match="Component field 'Parent.child' of type 'Base' has no default or configured class.",
+    ):
+        configure(Parent(), {"child_allow_missing": "Child2"})
+
+    # But missing out "child_allow_missing" should succeed.
+    instance = Parent()
+    configure(instance, {"child": "Child1"})
+    assert not hasattr(instance, "child_allow_missing")

--- a/zookeeper/core/field.py
+++ b/zookeeper/core/field.py
@@ -186,7 +186,7 @@ class ComponentField(Field, Generic[C, F]):
         default: Union[utils.Missing, F, PartialComponent[F]] = utils.missing,
         **kwargs,
     ):
-        if default in (utils.missing, None):
+        if default is utils.missing:
             if len(kwargs) > 0:
                 raise TypeError(
                     "Keyword arguments can only be passed to `ComponentField` if "
@@ -251,8 +251,6 @@ class ComponentField(Field, Generic[C, F]):
                 f"ComponentField '{self.name}' has no default or configured component "
                 "class."
             )
-        if self._default is None:
-            return self._default
         if not isinstance(component_instance, self.host_component_class):
             raise TypeError(
                 f"ComponentField '{self.name}' belongs to component "

--- a/zookeeper/core/field.py
+++ b/zookeeper/core/field.py
@@ -27,6 +27,8 @@ class Field(Generic[C, F]):
         default: Union[
             utils.Missing, F, Callable[[], F], Callable[[C], F]
         ] = utils.missing,
+        *,  # `allow_missing` must be a keyword argument.
+        allow_missing: bool = False,
     ):
         # Define here once to avoid having to define twice below.
         default_error = TypeError(
@@ -38,10 +40,16 @@ class Field(Generic[C, F]):
         )
 
         self.name = None
+        self.allow_missing = allow_missing
         self.host_component_class = None
         self.type = None
         self._registered = False
         self._return_annotation = inspect.Signature.empty
+
+        if allow_missing and default is not utils.missing:
+            raise ValueError(
+                "If a `Field` has `allow_missing=True`, no default can be provided."
+            )
 
         if default is utils.missing or utils.is_immutable(default):
             self._default = default
@@ -184,8 +192,15 @@ class ComponentField(Field, Generic[C, F]):
     def __init__(
         self,
         default: Union[utils.Missing, F, PartialComponent[F]] = utils.missing,
+        *,  # `allow_missing` must be a keyword argument.
+        allow_missing: bool = False,
         **kwargs,
     ):
+        if allow_missing and default is not utils.missing:
+            raise ValueError(
+                "If a `Field` has `allow_missing=True`, no default can be provided."
+            )
+
         if default is utils.missing:
             if len(kwargs) > 0:
                 raise TypeError(
@@ -207,6 +222,7 @@ class ComponentField(Field, Generic[C, F]):
             )
 
         self.name = utils.missing
+        self.allow_missing = allow_missing
         self.host_component_class = utils.missing
         self.type = utils.missing
         self._registered = False

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -184,12 +184,3 @@ def test_component_field_kwargs():
     default_value = A.foo.get_default(A())  # type: ignore
     assert isinstance(default_value, ConcreteComponent)
     assert default_value.a == 5
-
-
-def test_component_field_optional():
-    # This should not raise an exception...
-    ComponentField(None)
-
-    # ...but this should
-    with pytest.raises(TypeError):
-        ComponentField(None, a=1, b=2, c=3)

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -124,6 +124,16 @@ def test_prohibit_underscore_field_name():
             _field = Field()
 
 
+def test_allow_missing():
+    # This should succeed because we don't set a default value...
+    f = Field(allow_missing=True)
+    assert f.allow_missing
+
+    # ...but this should fail because there's a default provided
+    with pytest.raises(ValueError):
+        Field(3.14, allow_missing=True)
+
+
 # Used in the `ComponentField` tests below.
 class AbstractClass:
     a: int = Field()
@@ -184,3 +194,13 @@ def test_component_field_kwargs():
     default_value = A.foo.get_default(A())  # type: ignore
     assert isinstance(default_value, ConcreteComponent)
     assert default_value.a == 5
+
+
+def test_component_field_allow_missing():
+    # This should succeed because we don't set a default value...
+    f = ComponentField(allow_missing=True)
+    assert f.allow_missing
+
+    # ...but this should fail because there's a default provided
+    with pytest.raises(ValueError):
+        ComponentField(3.14, allow_missing=True)


### PR DESCRIPTION
This PR reverts the previous behaviour of allowing `None` values in `ComponentFields`, and instead allows the ability (in all fields) to specify that a value need not be provided.