### PR TITLE
Extend component example

### DIFF
--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -35,6 +35,7 @@ class A:
 class B:
     a: A = ComponentField()
     w: int = Field(5)
+    x: int = Field()
     y: str = Field("bar")
 
 @component
@@ -47,13 +48,13 @@ c = C()
 configure(
     c,
     {
-        "x": 5,                     # (1)
-        "b.x": 10,                  # (2)
-        "b.a.x": 15,                # (3)
+        "x": 5,                 # (1)
+        "b.x": 10,              # (2)
+        "b.a.x": 15,            # (3)
 
-        "b.y": "baz",               # (4)
+        "b.y": "baz",           # (4)
 
-        "b.z": 2.71                 # (5)
+        "b.a.z": 2.71           # (5)
     }
 )
 print(c)
@@ -61,16 +62,17 @@ print(c)
 >>  C(
         b = B(
             a = A(
-                w = 3,              # default from child, not parent
-                x = 15,             # (3) overrides (2) overrides (1)
-                y = "baz",          # (4) overrides child default
-                z = 2.71            # Inherits from parent: (5)
+                w = 3,          # Default value (not overriden by the parent default value)
+                x = 15,         # Configured value (3) overrides (2) overrides (1)
+                y = "baz",      # Parent configured value (4) overrides child default value
+                z = 2.71        # Configured value (5)
             ),
-            w = 5,                  # default
-            y = "baz"               # (4) overrides the default
+            w = 5,              # Default value
+            x = 10,             # Configured value (2) overrides (1)
+            y = "baz"           # Configured value (4) overrides the default value
         ),
-        x = 5,                      # Only (1) applies
-        z = 3.14                    # The default is taken
+        x = 5,                  # Configured value (1)
+        z = 3.14                # Default value
     )
 ```
 """

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -26,13 +26,16 @@ configuration scoping:
 ```
 @component
 class A:
+    w: int = Field(3)
     x: int = Field()
+    y: str = Field("foo")
     z: float = Field()
 
 @component
 class B:
     a: A = ComponentField()
-    y: str = Field("foo")
+    w: int = Field(5)
+    y: str = Field("bar")
 
 @component
 class C:
@@ -48,7 +51,7 @@ configure(
         "b.x": 10,                  # (2)
         "b.a.x": 15,                # (3)
 
-        "b.y": "bar",               # (4)
+        "b.y": "baz",               # (4)
 
         "b.z": 2.71                 # (5)
     }
@@ -58,10 +61,13 @@ print(c)
 >>  C(
         b = B(
             a = A(
+                w = 3,              # default from child, not parent
                 x = 15,             # (3) overrides (2) overrides (1)
+                y = "baz",          # (4) overrides child default
                 z = 2.71            # Inherits from parent: (5)
             ),
-            y = "bar"               # (4) overrides the default
+            w = 5,                  # default
+            y = "baz"               # (4) overrides the default
         ),
         x = 5,                      # Only (1) applies
         z = 3.14                    # The default is taken


### PR DESCRIPTION
I was confused by the inheritance behaviour in the component class; I added a few lines to make clear that defaults are not inherited from parents, while explicitly passed values are inherited.