### PR TITLE
Option for Sequence of losses (for models with multiple outputs)

### DIFF
--- a/zookeeper/tf/experiment.py
+++ b/zookeeper/tf/experiment.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, Sequence
 
 from tensorflow import keras
 
@@ -21,5 +21,7 @@ class Experiment:
     # Parameters
     epochs: int = Field()
     batch_size: int = Field()
-    loss: Optional[Union[keras.losses.Loss, str]] = Field()
+    loss: Optional[
+        Union[Sequence[Union[keras.losses.Loss, str]]], Union[keras.losses.Loss, str]
+    ] = Field()
     optimizer: Union[keras.optimizers.Optimizer, str] = Field()

--- a/zookeeper/tf/experiment.py
+++ b/zookeeper/tf/experiment.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence
+from typing import Optional, Sequence, Union
 
 from tensorflow import keras
 

--- a/zookeeper/tf/experiment.py
+++ b/zookeeper/tf/experiment.py
@@ -22,6 +22,6 @@ class Experiment:
     epochs: int = Field()
     batch_size: int = Field()
     loss: Optional[
-        Union[Sequence[Union[keras.losses.Loss, str]]], Union[keras.losses.Loss, str]
+        Union[Sequence[Union[keras.losses.Loss, str]], keras.losses.Loss, str]
     ] = Field()
     optimizer: Union[keras.optimizers.Optimizer, str] = Field()


### PR DESCRIPTION
Keras / Tensorflow allows for lists of losses when a model has multiple outputs. This change reflects this option in the Experiment loss field's type hint. 