### PR TITLE
Allow None in Keras loss multitask loss

### DIFF
--- a/zookeeper/tf/experiment.py
+++ b/zookeeper/tf/experiment.py
@@ -22,6 +22,6 @@ class Experiment:
     epochs: int = Field()
     batch_size: int = Field()
     loss: Optional[
-        Union[Sequence[Union[keras.losses.Loss, str]], keras.losses.Loss, str]
+        Union[Sequence[Union[keras.losses.Loss, str, None]], keras.losses.Loss, str]
     ] = Field()
     optimizer: Union[keras.optimizers.Optimizer, str] = Field()


### PR DESCRIPTION
When training multi output models, Keras allows to use `loss=None` for some branches. This PR adapts the typings to support this.