### PR TITLE
Fix _list_field_strings

### DIFF
--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -297,6 +297,7 @@ def _list_field_strings(instance, color: bool, single_line: bool) -> Iterator[st
             utils.generate_component_ancestors_with_field(instance, field_name), None
         )
         if value is not utils.missing and parent_instance is not None:
+            # Suppress warning for comparing literals, e.g. `5 is 6`.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 is_inherited = base_getattr(parent_instance, field_name) is value  # type: ignore

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -296,7 +296,6 @@ def _list_field_strings(instance, color: bool, single_line: bool) -> Iterator[st
             utils.generate_component_ancestors_with_field(instance, field_name), None
         )
         if value is not utils.missing and parent_instance is not None:
-            # Suppress warning for comparing literals, e.g. `5 is 6`.
             is_inherited = base_getattr(parent_instance, field_name) is value  # type: ignore
         else:
             is_inherited = False

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -79,6 +79,7 @@ print(c)
 
 import functools
 import inspect
+import warnings
 from typing import Any, Dict, Iterator, List, Optional, Type
 
 from zookeeper.core import utils
@@ -289,16 +290,16 @@ def _list_field_strings(instance, color: bool, single_line: bool) -> Iterator[st
         except AttributeError as e:
             if field.allow_missing:
                 value = utils.missing
-                yield f"{field_name}={value}" if color else f"{field_name}={value}"
-                continue
             else:
                 raise e from None
 
         parent_instance = next(
             utils.generate_component_ancestors_with_field(instance, field_name), None
         )
-        if parent_instance is not None:
-            is_inherited = base_getattr(parent_instance, field_name) is value  # type: ignore
+        if value is not utils.missing and parent_instance is not None:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                is_inherited = base_getattr(parent_instance, field_name) is value  # type: ignore
         else:
             is_inherited = False
 

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -81,8 +81,6 @@ import functools
 import inspect
 from typing import Any, Dict, Iterator, List, Optional, Type
 
-from tensorflow import is_tensor
-
 from zookeeper.core import utils
 from zookeeper.core.factory_registry import FACTORY_REGISTRY
 from zookeeper.core.field import ComponentField, Field
@@ -300,11 +298,7 @@ def _list_field_strings(instance, color: bool, single_line: bool) -> Iterator[st
             utils.generate_component_ancestors_with_field(instance, field_name), None
         )
         if parent_instance is not None:
-            parent_value = base_getattr(parent_instance, field_name)  # type: ignore
-            if is_tensor(parent_value):
-                is_inherited = parent_value is value
-            else:
-                is_inherited = parent_value == value
+            is_inherited = base_getattr(parent_instance, field_name) is value  # type: ignore
         else:
             is_inherited = False
 

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -79,7 +79,6 @@ print(c)
 
 import functools
 import inspect
-import warnings
 from typing import Any, Dict, Iterator, List, Optional, Type
 
 from zookeeper.core import utils

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -81,6 +81,8 @@ import functools
 import inspect
 from typing import Any, Dict, Iterator, List, Optional, Type
 
+from tensorflow import is_tensor
+
 from zookeeper.core import utils
 from zookeeper.core.factory_registry import FACTORY_REGISTRY
 from zookeeper.core.field import ComponentField, Field
@@ -289,6 +291,8 @@ def _list_field_strings(instance, color: bool, single_line: bool) -> Iterator[st
         except AttributeError as e:
             if field.allow_missing:
                 value = utils.missing
+                yield f"{field_name}={value}" if color else f"{field_name}={value}"
+                continue
             else:
                 raise e from None
 
@@ -296,7 +300,11 @@ def _list_field_strings(instance, color: bool, single_line: bool) -> Iterator[st
             utils.generate_component_ancestors_with_field(instance, field_name), None
         )
         if parent_instance is not None:
-            is_inherited = base_getattr(parent_instance, field_name) == value  # type: ignore
+            parent_value = base_getattr(parent_instance, field_name)  # type: ignore
+            if is_tensor(parent_value):
+                is_inherited = parent_value is value
+            else:
+                is_inherited = parent_value == value
         else:
             is_inherited = False
 

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -297,9 +297,7 @@ def _list_field_strings(instance, color: bool, single_line: bool) -> Iterator[st
         )
         if value is not utils.missing and parent_instance is not None:
             # Suppress warning for comparing literals, e.g. `5 is 6`.
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                is_inherited = base_getattr(parent_instance, field_name) is value  # type: ignore
+            is_inherited = base_getattr(parent_instance, field_name) is value  # type: ignore
         else:
             is_inherited = False
 

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -83,7 +83,8 @@ def test_no_init(ExampleComponentClass):
     # Verify that arguments are disallowed (the 1 positional argument the error
     # message refers to is `self`).
     with pytest.raises(
-        TypeError, match=r"takes 1 positional argument but 2 were given",
+        TypeError,
+        match=r"takes 1 positional argument but 2 were given",
     ):
         ExampleComponentClass("foobar")
 

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -83,8 +83,7 @@ def test_no_init(ExampleComponentClass):
     # Verify that arguments are disallowed (the 1 positional argument the error
     # message refers to is `self`).
     with pytest.raises(
-        TypeError,
-        match=r"takes 1 positional argument but 2 were given",
+        TypeError, match=r"takes 1 positional argument but 2 were given",
     ):
         ExampleComponentClass("foobar")
 


### PR DESCRIPTION
Fixes the bug mentioned in https://github.com/larq/zookeeper/pull/206#issuecomment-737396937. Also fixes another bug where printing a component that contains a tensor `Field` would throw a TensorFlow error, because the comparison with the parent value returned a boolean tensor rather than a boolean. This led TF to believe we were running in graph mode.

It would be good to add more unit tests for having an empty field with `allow_missing`, and for using tensors in various places, as both of these issues could have been identified through unit tests (we're probably not really testing the printing) 