### PR TITLE
Perform component configuration in a breadth-first order.

### DIFF
--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -425,7 +425,7 @@ def __component_init__(instance, **kwargs):
 #####################################
 
 
-def recursively_configure_component_instance(
+def configure_component_instance(
     instance,
     conf: Dict[str, Any],
     name: str,
@@ -762,7 +762,7 @@ def configure(
         if current_instance.__component_configured__:
             continue
 
-        recursively_configure_component_instance(
+        configure_component_instance(
             current_instance,
             conf=current_conf,
             name=current_name,

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -78,7 +78,7 @@ print(c)
 
 import functools
 import inspect
-from typing import Any, Dict, Iterator, List, Optional, Type
+from typing import AbstractSet, Any, Dict, Iterator, List, Optional, Type
 
 from zookeeper.core import utils
 from zookeeper.core.factory_registry import FACTORY_REGISTRY
@@ -312,51 +312,6 @@ def _wrap_dir(component_cls: Type) -> None:
     component_cls.__dir__ = wrapped_fn
 
 
-def _wrap_configure(component_cls: Type) -> None:
-    if hasattr(component_cls, "__configure__"):
-        if not callable(component_cls.__configure__):
-            raise TypeError(
-                "The `__configure__` attribute of a @component class must be a "
-                "method."
-            )
-        call_args = inspect.signature(component_cls.__configure__).parameters
-        configure_args = inspect.signature(configure).parameters
-
-        if not all(
-            arg_param.kind in (arg_param.VAR_POSITIONAL, arg_param.VAR_KEYWORD)
-            or arg_name in configure_args
-            or arg_name == "self"
-            for arg_name, arg_param in call_args.items()
-        ):
-            raise TypeError(
-                "The `__configure__` method of a @component class must match the "
-                f"arguments of `configure()`, but `{component_cls.__name__}.__configure__`"
-                f" accepts arguments {tuple(call_args)}. Valid "
-                f"arguments: ({', '.join(configure_args)})"
-            )
-
-        fn = component_cls.__configure__
-
-        @functools.wraps(fn)
-        def wrapped_configure(instance, *args, **kwargs):
-            fn(instance, *args, **kwargs)
-            if not instance.__component_configured__:
-                raise ValueError(
-                    f"`{instance.__component_name__}` remains unconfigured after "
-                    "calling __configure__! Make sure to call "
-                    "`configure(self, conf, **kwargs)` at the end of this function."
-                )
-
-        component_cls.__configure__ = wrapped_configure
-
-    else:
-        component_cls.__configure__ = __component__configure__
-
-
-def __component__configure__(instance, *args, **kwargs):
-    configure(instance, *args, **kwargs)
-
-
 #################################
 # Pretty string representations #
 #################################
@@ -491,6 +446,21 @@ def component(cls: Type):
         raise TypeError("Component classes must not define a custom `__init__` method.")
     cls.__init__ = __component_init__
 
+    if hasattr(cls, "__pre_configure__"):
+        if not callable(cls.__pre_configure__):
+            raise TypeError(
+                "The `__pre_configure__` attribute of a @component class must be a "
+                "method."
+            )
+        call_args = inspect.signature(cls.__pre_configure__).parameters
+        if len(call_args) > 2 or len(call_args) > 1 and "self" not in call_args:
+            raise TypeError(
+                "The `__pre_configure__` method of a @component class must take no "
+                f"arguments except `self` and `conf`, but "
+                f"`{cls.__name__}.__pre_configure__` accepts arguments "
+                f"{tuple(name for name in call_args)}."
+            )
+
     if hasattr(cls, "__post_configure__"):
         if not callable(cls.__post_configure__):
             raise TypeError(
@@ -538,7 +508,6 @@ def component(cls: Type):
     _wrap_setattr(cls)
     _wrap_delattr(cls)
     _wrap_dir(cls)
-    _wrap_configure(cls)
 
     # Components should have nice `__str__` and `__repr__` methods.
     cls.__str__ = __component_str__
@@ -552,33 +521,32 @@ def component(cls: Type):
     return cls
 
 
-def configure(
+def recursively_configure_component_instance(
     instance,
     conf: Dict[str, Any],
-    name: Optional[str] = None,
-    interactive: bool = False,
+    name: str,
+    fields_in_scope: AbstractSet[str],
+    interactive: bool,
 ):
     """Configure the component instance with parameters from the `conf` dict.
 
-    Configuration passed through `conf` takes precedence over and will
-    overwrite any values already set on the instance - either class defaults
-    or those set in `__init__`.
+    This method is recursively called for each component instance in the component tree
+    by the exported `configure` function.
     """
-    # Only component instances can be configured.
-    if not utils.is_component_instance(instance):
-        raise TypeError(
-            "Only @component, @factory, and @task instances can be configured. "
-            f"Received: {instance}."
-        )
-
-    # Configuration can only happen once.
-    if instance.__component_configured__:
-        raise ValueError(
-            f"Component '{instance.__component_name__}' has already been configured."
-        )
-
     if name is not None:
         instance.__component_name__ = name
+
+    if hasattr(instance.__class__, "__pre_configure__"):
+        conf = instance.__pre_configure__({**conf})
+        if not isinstance(conf, dict):
+            raise ValueError(
+                "Expected the `__pre_configure__` method of component "
+                f"'{instance.__component_name__}' to return a dict of configuration, "
+                f"but received: {conf}"
+            )
+
+    # Extend the field names in scope.
+    instance.__component_fields_with_values_in_scope__ |= fields_in_scope
 
     # Set the correct value for each field.
     for field in instance.__component_fields__.values():
@@ -616,9 +584,6 @@ def configure(
             instance.__component_configured_field_values__[
                 field.name
             ] = conf_field_value
-
-            # This value has now been 'consumed', so delete it from `conf`.
-            del conf[field.name]
 
         # If there's a value in scope, we don't need to do anything.
         elif field.name in instance.__component_fields_with_values_in_scope__:
@@ -743,44 +708,105 @@ def configure(
         elif key not in instance.__component_fields__:
             raise error
 
-    # Recursively configure any sub-components.
-    for field in instance.__component_fields__.values():
-        if not isinstance(field, ComponentField):
-            continue
-
-        try:
-            sub_component_instance = base_getattr(instance, field.name)
-        except (AttributeError, ConfigurationError) as e:
-            if field.allow_missing:
-                continue
-            raise e from None
-
-        if not utils.is_component_instance(sub_component_instance):
-            continue
-
-        full_name = f"{instance.__component_name__}.{field.name}"
-
-        if not sub_component_instance.__component_configured__:
-            # Extend the field names in scope. All fields with values defined in
-            # the scope of the parent are also accessible in the child.
-            sub_component_instance.__component_fields_with_values_in_scope__ |= (
-                instance.__component_fields_with_values_in_scope__
-            )
-
-            # Configure the nested sub-component. The configuration we use
-            # consists of all any keys scoped to `field.name`.
-            field_name_scoped_conf = {
-                a[len(f"{field.name}.") :]: b
-                for a, b in conf.items()
-                if a.startswith(f"{field.name}.")
-            }
-            sub_component_instance.__configure__(
-                field_name_scoped_conf,
-                name=full_name,
-                interactive=interactive,
-            )
-
     instance.__component_configured__ = True
 
     if hasattr(instance.__class__, "__post_configure__"):
         instance.__post_configure__()
+
+
+def configure(
+    instance,
+    conf: Dict[str, Any],
+    name: Optional[str] = None,
+    interactive: bool = False,
+):
+    """Configure the component instance with parameters from the `conf` dict.
+
+    Configuration passed through `conf` takes precedence over and will
+    overwrite any values already set on the instance - either class defaults
+    or those set in `__init__`.
+    """
+    # Only component instances can be configured.
+    if not utils.is_component_instance(instance):
+        raise TypeError(
+            "Only @component, @factory, and @task instances can be configured. "
+            f"Received: {instance}."
+        )
+
+    # Configuration can only happen once.
+    if instance.__component_configured__:
+        raise ValueError(
+            f"Component '{instance.__component_name__}' has already been configured."
+        )
+
+    # Maintain a FIFO queue of component instances that need to be configured,
+    # along with the config dict, name that should be passed, and a set of field
+    # names that are in-scope for component field inheritence.
+    #     This queue allows us to recursively configure component instances in
+    # the component tree in a top-down, breadth-first order.
+    fifo_component_queue = [(instance, conf, name, frozenset(conf.keys()))]
+
+    while len(fifo_component_queue) > 0:
+        (
+            current_instance,
+            current_conf,
+            current_name,
+            current_fields_in_scope,
+        ) = fifo_component_queue.pop(0)
+
+        if current_instance.__component_configured__:
+            continue
+
+        recursively_configure_component_instance(
+            current_instance,
+            conf=current_conf,
+            name=current_name,
+            fields_in_scope=current_fields_in_scope,
+            interactive=interactive,
+        )
+
+        # Collect the sub-component instances that need to be recursively
+        # configured, and add them to the queue.
+        for field in current_instance.__component_fields__.values():
+            if not isinstance(field, ComponentField):
+                continue
+
+            try:
+                sub_component_instance = base_getattr(current_instance, field.name)
+            except (AttributeError, ConfigurationError) as e:
+                if field.allow_missing:
+                    continue
+                raise e from None
+
+            if (
+                not utils.is_component_instance(sub_component_instance)
+                or sub_component_instance.__component_configured__
+            ):
+                continue
+
+            # Generate the configuration dict that will be used with the nested
+            # sub-component. This consists of all keys scoped to `field.name`.
+            sub_component_conf = {
+                a[len(f"{field.name}.") :]: b
+                for a, b in current_conf.items()
+                if a.startswith(f"{field.name}.")
+            }
+
+            # The name of the sub-component is full-stop-delimited.
+            sub_component_name = f"{current_instance.__component_name__}.{field.name}"
+
+            # At this point the current instance has already been configured so
+            # we know that every one of its fields is in scope.
+            sub_component_fields_in_scope = current_fields_in_scope | frozenset(
+                current_instance.__component_fields__.keys()
+            )
+
+            # Add the sub-component to the end of the queue.
+            fifo_component_queue.append(
+                (
+                    sub_component_instance,
+                    sub_component_conf,
+                    sub_component_name,
+                    sub_component_fields_in_scope,
+                )
+            )

--- a/zookeeper/core/task.py
+++ b/zookeeper/core/task.py
@@ -3,7 +3,7 @@ import inspect
 import click
 
 from zookeeper.core.cli import ConfigParam, cli
-from zookeeper.core.component import component
+from zookeeper.core.component import component, configure
 from zookeeper.core.utils import convert_to_snake_case
 
 
@@ -53,7 +53,7 @@ def task(cls):
     def command(config, interactive):
         config = {k: v for k, v in config}
         task_instance = cls()
-        task_instance.__configure__(config, interactive=interactive)
+        configure(task_instance, config, interactive=interactive)
         task_instance.run()
 
     return cls


### PR DESCRIPTION
### Why breadth-first traversal matters

Previously, components were greedily configured in a depth-first traversal of the component tree, meaning that instances which were inherited could get configured at the 'wrong' (non-topmost) level. This was a source of hard-to-identify bugs - e.g. @timdebruin and I ran into #226. This PR fixes that bug by configuring components in a breadth-first order. This guarantees that if a component instance appears multiple times in the component tree (because of inheritence), then it will be configured precisely once, at the *highest level*.

### Replacing `__component_configure__` with `__pre_configure__`

Unfortunately, I wasn't able to get this breadth-first configuration to naturally work with the existing `__component_configure__` method (cc @jneeven). This is because a breadth-first traversal order requires 'external ordering' and would mean that the `__component_configure__` method (which is responsible for configuring said instance's child sub-components) would have to be aware of this global ordering.

The solution I found for this problem was to instead replace the method with a `__pre_configure__` alternative (note that this name neatly pairs with the existing `__post_configure__`). Instead of overriding `__component_configure__` and being responsible for invoking component configuration directly, a user can instead override `__pre_configure__`, a method which receives the instance config dict as an argument and returns a new config dict (so that the user can modify/add new arbitrary field configuration as they wish).

The reason this works is that it allows the user-facing `configure` method to internally maintain an ordered queue of component instances that still need to be configured, along with the configuration that will be passed to them. In other words, if there are many component instances the order in which their `__pre_configure__` methods are called will not necessary match the order in which they are actually configured, allowing the 'external ordering' that I mentioned at the top of this section to be imposed.

### Review

The diff is quite messy, partly because I swapped the order of a few functions. For easier review, I have split this PR into two commits - the first contains all the functional code changes, and the second re-orders the functions. The diff should be cleaner if you look at the first commit alone.