### PR TITLE
Remove unused colorama import

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.7
       - name: Install project dependencies
         run: |
-          pip install tensorflow==2.4.1 colorama==0.4.4
+          pip install tensorflow-cpu==2.4.1
           pip install -e .[test]
       - name: Run Flake8
         run: flake8

--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -85,15 +85,6 @@ from zookeeper.core.factory_registry import FACTORY_REGISTRY
 from zookeeper.core.field import ComponentField, Field
 from zookeeper.core.utils import ConfigurationError
 
-try:  # pragma: no cover
-    from colorama import Fore, Style
-
-    RED, YELLOW = Fore.RED, Fore.YELLOW
-    BRIGHT, RESET_ALL = Style.BRIGHT, Style.RESET_ALL
-except ImportError:  # pragma: no cover
-    BRIGHT = RED = RESET_ALL = YELLOW = ""
-
-
 ###################################
 # Component class method wrappers #
 ###################################


### PR DESCRIPTION
The colour codes are never used in the code, so we can safely remove the imports