### PR TITLE
Fix CI issue by pinning Keras version to 2.6 for TF <= 2.6

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Fix tfds for TF 1.15/2.0
         run: pip install tensorflow_datasets==3.2.*
         if: matrix.tf-version == '1.15.5' || matrix.tf-version == '2.0.4'
+      - name: Pin Keras for older TF versions
+        run: pip install keras==2.6.0
+        if: matrix.tf-version <= '2.6.0'
       - name: Fix tfds for TF 2.1
         run: pip install tensorflow_datasets==4.2.0
         if: matrix.tf-version == '2.1.4'


### PR DESCRIPTION
CI was failing since yesterday because of a mismatching Keras version as suggested on [SO](https://stackoverflow.com/a/69830680/4807429). By explicitly installing `keras==2.6.0` it is resolved. It was caused by keras 2.7 being released yesterday (https://pypi.org/project/keras/#history) and since we don't pin it this caused issues.
