### PR TITLE
Allow components to have __init__ functions

### DIFF
--- a/zookeeper/core/component.py
+++ b/zookeeper/core/component.py
@@ -95,12 +95,11 @@ from zookeeper.core.utils import (
 # A component `__init__` #
 ##########################
 class ComponentInit:
-    """
-    We wrap both the original __init__ and the __component_init__ in this descriptor.
-    If we would simply store e.g. `__original__init` on every component, we
-    would run into problems with resolution of calls to `super().__init__()`, since they
-    would trigger `__component_init__` on the parent class again, with the same value
-    for the `instance` argument.
+    """We wrap both the original __init__ and the __component_init__ in this descriptor.
+    If we would simply store e.g. `__original__init` on every component, we would run
+    into problems with resolution of calls to `super().__init__()`, since they would
+    trigger `__component_init__` on the parent class again, with the same value for the
+    `instance` argument.
 
     By using a descriptor, we can effectively create a different `__component_init__`
     for every class, and thus make sure that `super().__init__()` refers to the correct
@@ -112,7 +111,8 @@ class ComponentInit:
 
     @staticmethod
     def __component_init__(instance, **kwargs):
-        """Accepts keyword-arguments corresponding to fields defined on the component."""
+        """Accepts keyword-arguments corresponding to fields defined on the
+        component."""
 
         # Use the `kwargs` to set field values.
         for name, value in kwargs.items():
@@ -154,9 +154,11 @@ class ComponentInit:
         ) | set(kwargs)
 
     def __get__(self, instance, type=None):
-        """`instance` is the instance on which `__init__` is called. If the instance
-        has not yet been configured, we defer to `__component_init__`. If it has been
-        configured, we defer to `self.original_init` instead to execute the user's code.
+        """`instance` is the instance on which `__init__` is called.
+
+        If the instance has not yet been configured, we defer to `__component_init__`.
+        If it has been configured, we defer to `self.original_init` instead to execute
+        the user's code.
         """
         if instance is None:
             # This happens when we call `__init__` on the class, e.g. `A.__init__`.

--- a/zookeeper/core/component_test.py
+++ b/zookeeper/core/component_test.py
@@ -8,7 +8,11 @@ import pytest
 from zookeeper.core.component import base_hasattr, component, configure
 from zookeeper.core.factory import factory
 from zookeeper.core.field import ComponentField, Field
-from zookeeper.core.utils import ConfigurationError, configuration_mode
+from zookeeper.core.utils import (
+    ConfigurationError,
+    configuration_mode,
+    in_configuration_mode,
+)
 
 
 @pytest.fixture
@@ -1106,6 +1110,8 @@ def test_component_configure_component_passed_as_config():
 
 
 def test_no_unconfigured_access():
+    assert not in_configuration_mode()
+
     @component
     class TestComponent:
         var: int = Field(5)

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -89,7 +89,7 @@ def test_decorated_field():
 
         @Field
         def bar(self) -> int:
-            return int(self.foo_value ** self.foo_value)
+            return int(self.foo_value**self.foo_value)
 
     instance = A()
 

--- a/zookeeper/core/field_test.py
+++ b/zookeeper/core/field_test.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 import pytest
 
-from zookeeper.core.component import component
+from zookeeper.core.component import component, configure
 from zookeeper.core.field import ComponentField, Field
 from zookeeper.core.partial_component import PartialComponent
 from zookeeper.core.utils import ConfigurationError
@@ -89,7 +89,7 @@ def test_decorated_field():
 
         @Field
         def bar(self) -> int:
-            return int(self.foo_value**self.foo_value)
+            return int(self.foo_value ** self.foo_value)
 
     instance = A()
 
@@ -181,6 +181,8 @@ def test_component_field_partial_component_default():
     assert A.foo.has_default
     default_value = A.foo.get_default(A())
     assert isinstance(default_value, ConcreteComponent)
+
+    configure(default_value, {})
     assert default_value.a == 5
 
 
@@ -194,6 +196,7 @@ def test_component_field_kwargs():
     assert A.foo.has_default
     default_value = A.foo.get_default(A())
     assert isinstance(default_value, ConcreteComponent)
+    configure(default_value, {})
     assert default_value.a == 5
 
 

--- a/zookeeper/core/utils.py
+++ b/zookeeper/core/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import re
 from ast import literal_eval
+from contextlib import contextmanager
 from typing import Any, Callable, Iterator, Sequence, Type, TypeVar
 
 import click
@@ -14,6 +15,26 @@ class Missing:
 
 
 missing = Missing()
+
+# Will be set to True if and only if zookeeper is currently in the process of configuring a component.
+_CONFIGURATION_MODE = False
+
+
+def in_configuration_mode():
+    return _CONFIGURATION_MODE
+
+
+@contextmanager
+def configuration_mode():
+    """Context manager that toggles _CONFIGURATION_MODE."""
+    global _CONFIGURATION_MODE
+    # It may already be True, if we're in a nested context.
+    prev_val = _CONFIGURATION_MODE
+    # But set it to True either way
+    _CONFIGURATION_MODE = True
+    yield
+    # And then set back to the original value.
+    _CONFIGURATION_MODE = prev_val
 
 
 class ConfigurationError(Exception):


### PR DESCRIPTION
Currently, zookeeper will throw an error if a component defines an `__init__`. This is annoying, because it makes it impossible to use zookeeper components that subclass existing classes that have one, e.g. `tf.keras.models.Model`. 

This PR changes that by:
- Allowing the user to define an `__init__` function, which will be called directly after configuration. This makes its behavior identical to `__post_configure__`, which is therefore deprecated. Neither function supports any arguments.
- Not allowing the user to access any of the fields on the component before it has been configured. This closes #280. The reason I've implemented this is that it would be very easy for bugs to appear if the user expects their `__init__` to have run, but the component was never configured. This means that users are now effectively forced to configure any and all zookeeper components they use, which may be overly strict in case all `Field`s already have default values. Before making this an official release, we could therefore consider automatically calling `configure` on a component if all its fields have default values. This is tricky, however, because the user may then _still_ configure it from the command line, and we wouldn't want the __init__ functions to be called multiple times.

