### PR TITLE
Update to the latest release-drafter

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,6 +9,6 @@ jobs:
   update_draft_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: toolmantim/release-drafter@v5.22
+      - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It would fail before (e.g. https://github.com/larq/zookeeper/actions/runs/5520583226/jobs/10067409407) with:
```
Error: Unable to resolve action `release-drafter/release-drafter@v5.22`, unable to find version `v5.22`
```
I've now set the version to what is recommended [here](https://github.com/release-drafter/release-drafter).