### PR TITLE
Support typeguard 3.x and 4.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "click>=7.0",
         "tensorflow-datasets>=1.3.0,<v4.9.0",
-        "typeguard>=2.5.1,<3.0.0",
+        "typeguard>=3.0",
         "protobuf<3.21",  # for tensorflow-datasets
     ],
     extras_require={

--- a/zookeeper/core/utils.py
+++ b/zookeeper/core/utils.py
@@ -96,11 +96,8 @@ def type_check(value, expected_type) -> bool:
             )
             return True
     try:
-        # typeguard.check_type requires a name as the first argument for their
-        # error message, but we want to catch their error so we can pass an
-        # empty string.
-        typeguard.check_type("", value, expected_type)
-    except TypeError:
+        typeguard.check_type(value, expected_type)
+    except typeguard.TypeCheckError:
         return False
     return True
 


### PR DESCRIPTION
typeguard 3.0 changed the signature of `check_type` (dropped the leading `argname` argument) and replaced the raised `TypeError` with a new `TypeCheckError` class that is not a subclass of `TypeError`. Update the `check_type` call and exception handler accordingly, and bump the pin from `>=2.5.1,<3.0.0` to `>=3.0`.

Verified against typeguard 3.0.2 and 4.5.2. All tests pass on both. Also unblocks downstream consumers (e.g. larq-zoo) that were stuck on typeguard <3 transitively.