### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name="zookeeper",
-    version="1.3.4",
+    version="1.4.0",
     author="Plumerai",
     author_email="opensource@plumerai.com",
     description="A small library for managing deep learning models, hyper-parameters and datasets",


### PR DESCRIPTION
Release the modernization work (ruff, Python >=3.10, typeguard >=3). Minor bump since dropping Python 3.8/3.9 and raising the typeguard floor  is breaking.